### PR TITLE
SOL-16122 mongo-k8s-sidecar: Fix error logging to print actual stack and add option to skip TLS verify of k8s APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ There you will also find some helper scripts to test out creating the replica se
 | MONGO_SIDECAR_UNHEALTHY_SECONDS | NO | 15 | This is how many seconds a replica set member has to get healthy before automatically being removed from the replica set. |
 | MONGO_PORT | NO | 27017 | Configures the mongo port, allows the usage of non-standard ports. |
 | CONFIG_SVR | NO | false | Configures the [configsvr](https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.configsvr) variable when initializing the replicaset. |
-| KUBERNETES_MONGO_SERVICE_NAME | NO |  | This should point to the MongoDB Kubernetes (headless) service that identifies all the pods. It is used for setting up the DNS configuration for the mongo pods, instead of the default pod IPs. Works only with the StatefulSets' stable network ID. |
-| KUBERNETES_CLUSTER_DOMAIN | NO | cluster.local | This allows the specification of a custom cluster domain name. Used for the creation of a stable network ID of the k8s Mongo   pods. An example could be: "kube.local". |
+| KUBE_MONGO_SERVICE_NAME | NO |  | This should point to the MongoDB Kubernetes (headless) service that identifies all the pods. It is used for setting up the DNS configuration for the mongo pods, instead of the default pod IPs. Works only with the StatefulSets' stable network ID. |
+| KUBE_CLUSTER_DOMAIN | NO | cluster.local | This allows the specification of a custom cluster domain name. Used for the creation of a stable network ID of the k8s Mongo   pods. An example could be: "kube.local". |
+| KUBE_CLUSTER_SKIP_TLS_VERIFY | NO | false | If `true`, the k8s server's certificate will not be checked for validity. |
 | MONGODB_USERNAME | NO | | Configures the mongo username for authentication |
 | MONGODB_PASSWORD | NO | | Configures the mongo password for authentication |
 | MONGODB_DATABASE | NO | local | Configures the mongo authentication database |
@@ -48,7 +49,7 @@ In its default configuration the sidecar uses the pods' IPs for the MongodDB rep
    ...} ]
 ```
 
-If you want to use the StatefulSets' stable network ID, you have to make sure that you have the `KUBERNETES_MONGO_SERVICE_NAME`
+If you want to use the StatefulSets' stable network ID, you have to make sure that you have the `KUBE_MONGO_SERVICE_NAME`
 environmental variable set. Then the MongoDB replica set node names could look like this:
 ```
 [ { _id: 1,
@@ -73,7 +74,7 @@ Read more about the stable network IDs
 
 An example for a stable network pod ID looks like this:
 `$(statefulset name)-$(ordinal).$(service name).$(namespace).svc.cluster.local`.
-The `statefulset name` + the `ordinal` form the pod name, the `service name` is passed via `KUBERNETES_MONGO_SERVICE_NAME`,
+The `statefulset name` + the `ordinal` form the pod name, the `service name` is passed via `KUBE_MONGO_SERVICE_NAME`,
 the namespace is extracted from the pod metadata and the rest is static.
 
 A thing to consider when running a cluster with the mongo-k8s-sidecar is that it will prefer the stateful set stable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-k8s-sidecar",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Kubernetes sidecar for MongoDB",
   "main": "src/index.ts",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-k8s-sidecar",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Kubernetes sidecar for MongoDB",
   "main": "src/index.ts",
   "type": "commonjs",

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ interface Config {
 
 interface KubeConfig {
   clusterDomain: string;
+  clusterSkipTLSVerify: boolean;
   labelSelector: string;
   mongoServiceName: string;
   namespace: string;
@@ -61,6 +62,7 @@ const loadConfig = (): Config => {
   return {
     kube: {
       clusterDomain: process.env.KUBE_CLUSTER_DOMAIN || "cluster.local",
+      clusterSkipTLSVerify: process.env.KUBE_CLUSTER_SKIP_TLS_VERIFY === "true",
       labelSelector: process.env.MONGO_SIDECAR_POD_LABELS || "app=solidatus-db",
       mongoServiceName: process.env.KUBE_MONGO_SERVICE_NAME || "db",
       namespace: process.env.KUBE_NAMESPACE || "default",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,4 @@ const main = async (): Promise<void> => {
     await sleep(config.mongo.loopSleepSeconds * 1000);
   }
 };
-main().catch((err) => log.error(err));
+main().catch((err) => log.error("Error in main func", err));

--- a/src/k8s.ts
+++ b/src/k8s.ts
@@ -1,9 +1,20 @@
-import { CoreV1Api, KubeConfig, V1Pod } from "@kubernetes/client-node";
+import { CoreV1Api, KubeConfig } from "@kubernetes/client-node";
 
 import { config } from "./config";
 
+import type { Cluster, V1Pod } from "@kubernetes/client-node";
+
 const kc = new KubeConfig();
 kc.loadFromDefault();
+
+if (config.kube.clusterSkipTLSVerify) {
+  // Cluster.skipTLSVerify is readonly. Let's respect it and create new cluster objects.
+  // Assigning to KubeConfig.clusters appears to be the way, same as the 'loadFromCluster' in config.js of the k8s client lib.
+  kc.clusters = kc.clusters.map<Cluster>((cluster) => ({
+    ...cluster,
+    skipTLSVerify: true,
+  }));
+}
 
 const k8sApi = kc.makeApiClient(CoreV1Api);
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,15 +1,13 @@
 import chalk from "chalk";
 
-type OptionalParam = boolean | number | object | string | unknown;
-
 const getDate = (): string => new Date().toISOString();
 
 const log = {
-  error: (msg: string, ...optionalParams: OptionalParam[]) =>
+  error: (msg: string, ...optionalParams: unknown[]) =>
     console.error(`[${getDate()}] ${chalk.red("ERROR")}: ${msg}`, ...optionalParams),
-  info: (msg: string, ...optionalParams: OptionalParam[]) =>
+  info: (msg: string, ...optionalParams: unknown[]) =>
     console.log(`[${getDate()}] ${chalk.green("INFO")}: ${msg}`, ...optionalParams),
-  warn: (msg: string, ...optionalParams: OptionalParam[]) =>
+  warn: (msg: string, ...optionalParams: unknown[]) =>
     console.warn(`[${getDate()}] ${chalk.yellow("WARN")}: ${msg}`, ...optionalParams),
 };
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,12 +1,12 @@
 import chalk from "chalk";
 
-type OptionalParam = boolean | number | object | string;
+type OptionalParam = boolean | number | object | string | unknown;
 
 const getDate = (): string => new Date().toISOString();
 
 const log = {
   error: (msg: string, ...optionalParams: OptionalParam[]) =>
-    console.trace(`[${getDate()}] ${chalk.red("ERROR")}: ${msg}`, ...optionalParams),
+    console.error(`[${getDate()}] ${chalk.red("ERROR")}: ${msg}`, ...optionalParams),
   info: (msg: string, ...optionalParams: OptionalParam[]) =>
     console.log(`[${getDate()}] ${chalk.green("INFO")}: ${msg}`, ...optionalParams),
   warn: (msg: string, ...optionalParams: OptionalParam[]) =>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,8 +43,7 @@ const workloop = async (): Promise<void> => {
         if (err.code === 94) {
           await notInReplicaSet(db, runningPods);
         } else if (err.code === 93) {
-          const status = await replSetGetStatus(db);
-          await invalidReplicaSet(db, runningPods, status);
+          await invalidReplicaSet(db, runningPods);
         } else {
           throw err;
         }
@@ -113,9 +112,7 @@ const notInReplicaSet = async (db: Db, pods: V1Pod[]): Promise<void> => {
   }
 };
 
-const invalidReplicaSet = async (db: Db, pods: V1Pod[], status: ReplSetStatus): Promise<void> => {
-  const members = status.members ?? [];
-
+const invalidReplicaSet = async (db: Db, pods: V1Pod[]): Promise<void> => {
   log.info("Invalid replica set");
   if (!podElection(pods)) {
     log.info("Didn't win pod election, returning");
@@ -123,8 +120,8 @@ const invalidReplicaSet = async (db: Db, pods: V1Pod[], status: ReplSetStatus): 
   }
 
   log.info("Won pod election, forcing reinit");
-  const addrToAdd = addrToAddLoop(pods, members);
-  const addrToRemove = addrToRemoveLoop(members);
+  const addrToAdd = addrToAddLoop(pods, []);
+  const addrToRemove = addrToRemoveLoop([]);
 
   await addNewReplSetMembers(db, addrToAdd, addrToRemove, true);
 };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,9 +53,7 @@ const workloop = async (): Promise<void> => {
       }
     }
   } catch (err) {
-    if (err instanceof Error) {
-      log.error(err.message);
-    }
+    log.error("Error in worker workloop", err);
   }
 };
 


### PR DESCRIPTION
- Errors printed stack trace from `log.ts` module, not from error object. Fix by passing through err obj to corrcetly print stack traces
- Juno cluster is slightly misconfigured, with the two nodes having different `front-proxy-*` certs. To fix looks like you need to remove then add back node to cluster, but scary. So instead add `KUBE_CLUSTER_SKIP_TLS_VERIFY` which will set `skipTLSVerify` on all loaded clusters
- `replSetGetStatus` on error, [never returned both](https://github.com/solidatus/mongo-k8s-sidecar/blob/53fa26339a04fe63e02242abd132425432f25eee/src/lib/mongo.js#L59) `err` & `status`. So into `invalidReplicaSet`, `status` was always missing. When we added an extra call to `replSetGetStatus` [just before](https://github.com/solidatus/mongo-k8s-sidecar/blob/f9e2bb02390ced74138b6209111b9a7514dd2db0/src/worker.ts#L46C32-L46C48) `invalidReplicaSet` causes an infinite loop, as on invalid config, it is exactly `replSetGetStatus` that fails and throws. So `members` used to be _always_ empty arr, make it so now too