### PR TITLE
SOL-16129: Implement MongoDB client singleton pattern to prevent conn…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "configsvr",
+        "Reconfig"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-k8s-sidecar",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Kubernetes sidecar for MongoDB",
   "main": "src/index.ts",
   "type": "commonjs",

--- a/src/mongo.ts
+++ b/src/mongo.ts
@@ -5,9 +5,17 @@ import { log } from "./log";
 import { ReplSetConfig, ReplSetStatus } from "./types";
 import { range, sleep } from "./utils";
 
-let mongoClient: MongoClient;
+let mongoClient: MongoClient | null = null;
 
 const getDb = async (host: string = "127.0.0.1"): Promise<Db> => {
+  if (mongoClient === null) {
+    mongoClient = await createMongoClient(host);
+  }
+
+  return mongoClient.db();
+};
+
+const createMongoClient = async (host: string): Promise<MongoClient> => {
   const mongoConfig = config.mongo;
   const authConfig = mongoConfig.auth;
 
@@ -19,15 +27,8 @@ const getDb = async (host: string = "127.0.0.1"): Promise<Db> => {
     uri += `/${authConfig.database}`;
   }
 
-  if (mongoClient) {
-    try {
-      return mongoClient.db();
-    } catch {
-      mongoClient.close();
-    }
-  }
-
-  mongoClient = new MongoClient(uri, {
+  const mongoClient = new MongoClient(uri, {
+    appName: "mongo-k8s-sidecar",
     directConnection: true,
     tls: mongoConfig.tls,
     tlsAllowInvalidCertificates: mongoConfig.tlsAllowInvalidCertificates,
@@ -35,9 +36,10 @@ const getDb = async (host: string = "127.0.0.1"): Promise<Db> => {
   });
 
   // test the connection
+  log.info("Connecting to MongoDB");
   await mongoClient.connect();
 
-  return mongoClient.db();
+  return mongoClient;
 };
 
 const replSetGetConfig = async (db: Db): Promise<ReplSetConfig> => {


### PR DESCRIPTION
After implementing the MongoDB client singleton pattern to prevent connection leaks, it appears that the connection count is now being controlled properly and is not increasing over time.
<img width="1033" alt="Screenshot 2025-01-20 at 2 50 38 PM" src="https://github.com/user-attachments/assets/b446cf16-25c0-45e9-81c9-5d42d01456b4" />
<img width="1434" alt="Screenshot 2025-01-21 at 9 59 58 AM" src="https://github.com/user-attachments/assets/652ab248-d512-4422-b8f7-5ff26eb4a78f" />


@mix4242, I tried to look for better documentation on the best way to have MongoClient in the nodes of the sidecar. However, I only found this link, which isn't directly related, but it's the best I could find: https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connect/