### PR TITLE
Fix infinite loop when existing config has member with id 1, so 0 always returned, which is falsey, so -1 always set and error always thrown

### DIFF
--- a/src/mongo.ts
+++ b/src/mongo.ts
@@ -96,7 +96,7 @@ const addNewMembers = (rsConfig: ReplSetConfig, addrs: string[]): void => {
 
   for (const addr of addrs) {
     // search for the next available member ID (max 255)
-    newMemberId = range(newMemberId, 256).find((i) => !memberIds.includes(i)) || -1;
+    newMemberId = range(newMemberId, 256).find((i) => !memberIds.includes(i)) ?? -1;
     if (newMemberId === -1) {
       throw new Error("No available member ID");
     }


### PR DESCRIPTION
Fix infinite loop when existing config has member with id 1, so 0 always returned, which is falsey, so -1 always set and error always thrown