### PR TITLE
SOL-19489 mongo-k8s-sidecar: Upgrade to TypeScript 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,3 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions: [">= 25.0.0"]
-      # SOL-19173 Upgrade to TypeScript 6.x
-      - dependency-name: "typescript"
-        versions: [">= 6.0.0"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
     "cSpell.words": [
         "adduser",
         "configsvr",
-        "Reconfig"
-    ]
+        "Reconfig",
+        "workloop"
+    ],
+    "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint-plugin-perfectionist": "^5.9.0",
         "eslint-plugin-prettier": "^5.5.5",
         "prettier": "3.8.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.3"
       },
       "engines": {
@@ -2147,9 +2147,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-perfectionist": "^5.9.0",
     "eslint-plugin-prettier": "^5.5.5",
     "prettier": "3.8.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.3"
   }
 }

--- a/src/mongo.ts
+++ b/src/mongo.ts
@@ -68,7 +68,7 @@ const initReplSet = async (db: Db, host: string): Promise<void> => {
   log.info("initial rsConfig", rsConfig);
 
   rsConfig.configsvr = config.mongo.isConfigSvr;
-  rsConfig.members[0].host = host;
+  rsConfig.members[0]!.host = host;
 
   const retryTimes = 20;
   const sleepInterval = 500;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ const getLocalIp = (): string | undefined => {
       return iface.address;
     }
   }
+  return;
 };
 
 const getHostname = (): string => os.hostname();
@@ -24,8 +25,8 @@ const getPodIp = (pod: V1Pod): string | undefined => {
   return pod.status?.podIP ? `${pod.status?.podIP}:${config.mongo.port}` : undefined;
 };
 
-const getPodFqdn = (pod: V1Pod): string | undefined => {
-  const hostname = pod.spec?.hostname ?? pod.metadata?.name;
+const getPodFqdn = (pod: undefined | V1Pod): string | undefined => {
+  const hostname = pod?.spec?.hostname ?? pod?.metadata?.name;
 
   return hostname ?
       `${hostname}.${config.kube.mongoServiceName}.${config.kube.namespace}.svc.${config.kube.clusterDomain}:${config.mongo.port}`

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -138,7 +138,7 @@ const podElection = (pods: V1Pod[]): boolean => {
     return aIp.localeCompare(bIp);
   });
 
-  return pods[0].status?.podIP === hostIp;
+  return pods[0]?.status?.podIP === hostIp;
 };
 
 const addrToAddLoop = (pods: V1Pod[], members: ReplSetStatusMember[]): string[] => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,34 @@
 {
+  /* Check out https://node.green & https://github.com/tsconfig/bases for some good info */
+  /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+  /* Include all TS files */
+  "include": ["./**/*.ts"],
   "compilerOptions": {
-    "target": "ESNext",
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-
-    "module": "NodeNext",
     "rootDir": "./src",
-    "moduleResolution": "node16",
-    "types": ["node"],
-
-    "inlineSourceMap": true,
     "outDir": "dist",
 
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
+    /* Follow https://github.com/tsconfig/bases/blob/main/bases/node24.json */
+    "target": "es2024",
+    /* Follow https://github.com/tsconfig/bases/blob/main/bases/node24.json but minimise to what we acc use */
+    "lib": ["es2024"],
+    /* Follow https://github.com/tsconfig/bases/blob/main/bases/node24.json */
+    "module": "nodenext",
+    /* We're on modern Node & TS so use this AI recommended module resolution */
+    "moduleResolution": "nodenext",
+    /* Follow TS v6 guide */
+    "types": ["node"],
 
-    "strict": true,
-
+    /* Follow https://github.com/tsconfig/bases/blob/main/bases/node24.json */
     "skipLibCheck": true,
-    "resolveJsonModule": true
-  },
-  "exclude": ["node_modules", "dist"]
+
+    /* Include 'undefined' in index signature results so callers have to check */
+    "noUncheckedIndexedAccess": true,
+    /* AI recommended, seems good */
+    "noImplicitReturns": true,
+    /* AI recommended, seems good */
+    "noFallthroughCasesInSwitch": true,
+    /* AI recommended, seems good */
+    "noImplicitOverride": true,
+  }
 }


### PR DESCRIPTION
[SOL-19489](https://solidatus.myjetbrains.com/youtrack/issue/SOL-19489) mongo-k8s-sidecar: Upgrade to TypeScript 6.x