### PR TITLE
SOL-20163 mongo-k8s-sidecar: Normalize pod hostname to FQDNs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 node_modules/
 example/
 dist/
+tests/
+reports/

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,7 +2,7 @@ changelog:
   categories:
     - title: 🏕 Changes
       labels:
-        - '*'
+        - "*"
       exclude:
         labels:
           - dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Test reports
+reports/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,4 @@
 {
-    "cSpell.words": [
-        "adduser",
-        "configsvr",
-        "Reconfig",
-        "workloop"
-    ],
-    "typescript.tsdk": "node_modules/typescript/lib"
+  "cSpell.words": ["adduser", "configsvr", "Reconfig", "workloop"],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
+Releases before 0.18.0: see git history.
+
+## [0.18.0]
+
+### Added
+
+- `KUBE_NORMALIZE_MEMBER_HOSTS` (default `true`): rename existing members onto the pod's stable network ID, one per cycle.
+- `MONGODB_FORCE_RECONFIG_GRACE_SECONDS` (default `30`): how long the set is left to elect a primary of its own before a sidecar writes a forced reconfig, and how long it waits before writing another.
+- `LOG_DEBUG` and a `log.debug` level; full replica set config logged there.
+- Unit tests (`vitest`), run with `npm test`.
+
+### Changed
+
+- Match a pod against members by pod IP, short name, bare pod name, or mongod's `self` flag - not just exact FQDN. Stops duplicate members.
+- Reap dead members before renaming; skip renames while any removal is pending. Otherwise the two wedge each other.
+- Time the unhealthy grace period from first-seen-unhealthy when `lastHeartbeatRecv` is the epoch, so starting members aren't removed early.
+- Log removals with `lastHeartbeatMessage`, state and unhealthy duration.
+- `replSetReconfig` logs members/version/force after the version increment; full config moved to debug.
+- Build via `tsconfig.build.json`, keeping tests out of `dist`.
+
+### Fixed
+
+- Cache one MongoDB client per host instead of one globally. The "is any peer already in a replica set?" guard before `replSetInitiate` was probing the local mongod for every peer, so it always answered no - a pod that came up with an empty data dir and won the IP-sorted election could initiate a competing set alongside the live one.
+- Peer probes get a 3s connect/server-selection timeout and no longer throw, so one unreachable pod can't stall or abort a work loop iteration. Clients dropped after a connection-level failure, since pod IPs get recycled.
+- Crash when `replSetGetStatus` omits `members` (state `REMOVED`); now waits to be re-added.
+- Forced reconfigs (the no-primary path, and error 93 recovery) are fenced by time. `force` skips mongod's config version and term check, so with a sidecar per mongod two pods whose pod lists disagree could both win their own election and write over each other, silently dropping a member. Both paths now wait out `MONGODB_FORCE_RECONFIG_GRACE_SECONDS` before forcing - most no-primary spells are just an election in progress - and won't force again until that long after the last one, which also stops a run of renames becoming a run of forced reconfigs.
+- Replica set bootstrap takes its seed address from the pod that won the election rather than from the first entry of the pod list, which the election used to reorder in place as a side effect.
+- A probe that fails to authenticate (codes 13, 18) now says so and names the credentials to check. It is still reported as in-set, since guessing otherwise splits the brain, but it is our own misconfiguration and it blocks bootstrap until fixed.
+- README settings table matched to the code (`MONGODB_*` names, corrected defaults).

--- a/Dockerfile.itest
+++ b/Dockerfile.itest
@@ -1,0 +1,22 @@
+# Test-runner image for the integration harness - see docker-compose.itest.yml.
+#
+# The checkout is baked into an image rather than bind-mounted, because a bind mount resolves against
+# the docker *daemon's* filesystem, not the client's. On a containerised CI agent (the agent runs in a
+# container with the host's docker socket mounted) the agent's checkout path does not exist on the
+# daemon side, so docker silently creates an empty directory there and mounts that - the tests then
+# fail with npm's "can only install with an existing package-lock.json". Build context travels over
+# the docker socket instead, so this works wherever the daemon lives.
+#
+# tests/ is excluded by the root .dockerignore, which exists for the production image; the COPY of
+# tests/ below is why this build has its own Dockerfile.itest.dockerignore.
+FROM node:24
+
+WORKDIR /app
+
+# Separate layer so a source-only change does not reinstall dependencies
+COPY package.json package-lock.json .npmrc ./
+RUN npm clean-install
+
+COPY tsconfig.json tsconfig.build.json vitest.integration.config.mts ./
+COPY src/ ./src/
+COPY tests/ ./tests/

--- a/Dockerfile.itest.dockerignore
+++ b/Dockerfile.itest.dockerignore
@@ -1,0 +1,7 @@
+# BuildKit prefers <dockerfile>.dockerignore over the root .dockerignore, which excludes tests/ for
+# the production image - the integration image needs them.
+.git/
+node_modules/
+dist/
+example/
+reports/

--- a/README.md
+++ b/README.md
@@ -23,23 +23,29 @@ There you will also find some helper scripts to test out creating the replica se
 
 ### Settings
 
+Boolean variables are read as the literal string `true` unless stated otherwise.
+
 | Environment Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| KUBE_NAMESPACE | NO |  | The namespace to look up pods in. Not setting it will search for pods in all namespaces. |
-| MONGO_SIDECAR_POD_LABELS | YES |  | This should be a comma separated list of key values the same as the podTemplate labels. See above for example. |
-| MONGO_SIDECAR_SLEEP_SECONDS | NO | 5 | This is how long to sleep between work cycles. |
-| MONGO_SIDECAR_UNHEALTHY_SECONDS | NO | 15 | This is how many seconds a replica set member has to get healthy before automatically being removed from the replica set. |
-| MONGO_PORT | NO | 27017 | Configures the mongo port, allows the usage of non-standard ports. |
-| CONFIG_SVR | NO | false | Configures the [configsvr](https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.configsvr) variable when initializing the replicaset. |
-| KUBE_MONGO_SERVICE_NAME | NO |  | This should point to the MongoDB Kubernetes (headless) service that identifies all the pods. It is used for setting up the DNS configuration for the mongo pods, instead of the default pod IPs. Works only with the StatefulSets' stable network ID. |
+| KUBE_NAMESPACE | NO | default | The namespace to look up pods in. |
+| MONGO_SIDECAR_POD_LABELS | NO | app=solidatus-db | The label selector used to find the mongo pods. This should be a comma separated list of key values the same as the podTemplate labels. See above for example. |
+| MONGODB_LOOP_SLEEP_SECONDS | NO | 5 | This is how long to sleep between work cycles. |
+| MONGODB_UNHEALTHY_SECONDS | NO | 15 | This is how many seconds a replica set member that has been reachable at least once has to get healthy again before automatically being removed from the replica set. |
+| MONGODB_STARTUP_GRACE_SECONDS | NO | 300 | This is how many seconds a member that has never been reachable is given before being removed. A mongod loading a large dataset is not reachable yet but its pod is Running, so removing it early only gets it re-added on the next cycle. Values below MONGODB_UNHEALTHY_SECONDS are ignored. |
+| MONGODB_FORCE_RECONFIG_GRACE_SECONDS | NO | 30 | This is how many seconds the set is left to elect a primary of its own before a sidecar writes a forced reconfig, and how long it then waits before writing another. A forced reconfig skips MongoDB's config version check, so two sidecars writing one at the same time lose one of the two updates; the wait keeps that to states the set cannot get out of by itself. Should comfortably exceed the replica set's `electionTimeoutMillis` (10s by default). |
+| MONGODB_PORT | NO | 27017 | Configures the mongo port, allows the usage of non-standard ports. |
+| MONGODB_CONFIG_SVR | NO | false | Configures the [configsvr](https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.configsvr) variable when initializing the replicaset. Accepts `y`, `yes`, `true` or `1`. |
+| KUBE_MONGO_SERVICE_NAME | NO | db | This should point to the MongoDB Kubernetes (headless) service that identifies all the pods. It is used for setting up the DNS configuration for the mongo pods, instead of the default pod IPs. Works only with the StatefulSets' stable network ID. |
 | KUBE_CLUSTER_DOMAIN | NO | cluster.local | This allows the specification of a custom cluster domain name. Used for the creation of a stable network ID of the k8s Mongo   pods. An example could be: "kube.local". |
 | KUBE_CLUSTER_SKIP_TLS_VERIFY | NO | false | If `true`, the k8s server's certificate will not be checked for validity. |
-| MONGODB_USERNAME | NO | | Configures the mongo username for authentication |
-| MONGODB_PASSWORD | NO | | Configures the mongo password for authentication |
-| MONGODB_DATABASE | NO | local | Configures the mongo authentication database |
-| MONGO_SSL_ENABLED | NO | false | Enable SSL for MongoDB. |
-| MONGO_SSL_ALLOW_INVALID_CERTIFICATES | NO | true | This should be set to true if you want to use self signed certificates. |
-| MONGO_SSL_ALLOW_INVALID_HOSTNAMES | NO | true | This should be set to true if your certificates FQDN's do not match the host name set in your replset. |
+| KUBE_NORMALIZE_MEMBER_HOSTS | NO | true | Existing replica set members whose host is not the pod's stable network ID are renamed to it, one member per work cycle. Set to `false`, `no`, `n` or `0` (case-insensitive) to leave existing member hosts untouched. Any other value - including an unrecognised one - leaves normalization on. |
+| LOG_DEBUG | NO | false | If `true`, logs additional detail, including the full replica set config on every reconfig. |
+| MONGODB_USERNAME | NO | | Configures the mongo username for authentication. Authentication is only used if both this and `MONGODB_PASSWORD` are set. |
+| MONGODB_PASSWORD | NO | | Configures the mongo password for authentication. |
+| MONGODB_AUTHDB | NO | | Configures the mongo authentication database. |
+| MONGODB_TLS | NO | false | Enable TLS for MongoDB. |
+| MONGODB_TLS_ALLOW_INVALID_CERTIFICATES | NO | false | This should be set to `true` if you want to use self signed certificates. |
+| MONGODB_TLS_ALLOW_INVALID_HOSTNAMES | NO | false | This should be set to `true` if your certificates FQDN's do not match the host name set in your replset. |
 
 In its default configuration the sidecar uses the pods' IPs for the MongodDB replica names. Here is a trimmed example:
 ```
@@ -86,27 +92,29 @@ The `statefulset name` + the `ordinal` form the pod name, the `service name` is 
 the namespace is extracted from the pod metadata and the rest is static.
 
 A thing to consider when running a cluster with the mongo-k8s-sidecar is that it will prefer the stateful set stable
-network ID to the pod IP. It is however compatible with replica sets, configured with the pod IP as identifier - the sidecar
-should not add an additional entry for it, nor alter the existing entries. The mongo-k8s-sidecar should only use the stable
-network ID for new entries in the cluster.
+network ID to the pod IP, for both new entries and existing ones. A member host has to identify one specific mongod and
+resolve from outside the namespace, and the stable network ID is the only form that does both, so by default the sidecar
+renames existing members onto it - one member per work cycle, in its own reconfig. Set `KUBE_NORMALIZE_MEMBER_HOSTS` to
+`false`, `no`, `n` or `0` (case-insensitive, surrounding whitespace ignored) to leave existing member hosts as they are.
+Normalization is on by default, and only those spellings turn it off - any other value, including a typo such as `off` or
+`disabled`, leaves it on.
 
-Finally if you have a preconfigured replica set you have to make sure that:
-- the names of the mongo nodes are their IPs
-- the names of the mongo nodes are their stable network IDs (for more info see the link above)
+The sidecar recognises a pod that is already a member under a name it would not have chosen itself, and will not add a
+second entry for it. That covers the pod IP, the namespace-scoped short name (`mongo-prod-0.mongodb:27017`), and - via
+mongod's own `self` flag - a name that identifies no pod at all, such as a bare headless service name. Adding a duplicate
+entry for a mongod that is already a member makes mongod report `Received heartbeat from member with the same member ID
+as ourself`, and the duplicate is then removed as unhealthy and re-added on every cycle.
 
-Example of compatible mongo replica names:
+Example of mongo replica names the sidecar understands:
 ```
 10.48.0.72:27017 # Uses the default pod IP name
+mongo-prod-0.mongodb:27017 # Uses the namespace-scoped short name
 mongo-prod-0.mongodb.db-namespace.svc.cluster.local:27017 # Uses the stable network ID
 ```
 
-Example of not compatible mongo replica names:
-```
-mongodb-service-0 # Uses some custom k8s service name. Risks being a duplicate entry for the same mongo.
-```
-
-If you run the sidecar alongside such a cluster, it may lead to a broken replica set, so make sure to test it well before
-going to production with it (which applies for all software).
+With normalization enabled, all of the above converge on the stable network ID. Anything that points at more than one
+mongod - a bare headless service name, for example - is only recognised for the pod running the sidecar itself, so avoid
+it in a preconfigured replica set.
 
 #### MongoDB Command
 The following is an example of how you would update the mongo command enabling ssl and using a certificate obtained from a secret and mounted at /data/ssl/mongodb.pem
@@ -144,7 +152,7 @@ Volume & Volume Mount
           env:
             - name: MONGO_SIDECAR_POD_LABELS
               value: "role=mongo,environment=prod"
-            - name: MONGO_SSL_ENABLED
+            - name: MONGODB_TLS
               value: 'true'
       volumes:
         - name: mongo-ssl
@@ -171,12 +179,55 @@ or
 Generate them on your own and push the secrets `kube create secret generic mongo --from-file=./keys`
 where `keys` is a directory containing your SSL pem file named `mongodb.pem`
 
+## Tests
+
+Everything test related lives in `tests/`:
+
+| Path                              | What                                                | How to run                 |
+| --------------------------------- | --------------------------------------------------- | -------------------------- |
+| `tests/*.test.ts`                 | Unit tests. No mongod, no Kubernetes, milliseconds.  | `npm test`                 |
+| `tests/integration/*.integration.test.ts` | Integration tests against three real mongods. | `npm run test:integration` |
+
+On TeamCity use `npm run test-teamcity` and `npm run test:integration-teamcity` instead: same tests,
+plus a JUnit XML report under `reports/` for TeamCity's XML report processing to pick up. Always add
+`npm run test:integration:down` as an always-run step, since an interrupted suite leaves the mongods up
+holding their replica set config.
+
+### Integration tests
+
+`npm run test:integration` brings up `docker-compose.itest.yml`: three `mongo:7` containers plus a
+container running the test suite, and takes about a minute.
+
+The only thing faked is the Kubernetes API: the pod list is stubbed, and everything else - the
+connections, `replSetInitiate`, every reconfig, the elections and the heartbeats - is real. The
+harness mirrors the real deployment closely enough that this works:
+
+- the test runner shares mongo-0's network namespace, so exactly as in a pod, `127.0.0.1` is its own
+  mongod and `getLocalIp()` returns an address the pod list also claims
+- each mongod carries its pod FQDN as a network alias, so member hosts written as
+  `db-0.db.test-ns.svc.cluster.local` resolve and heartbeat for real
+- addresses are static, with mongo-0's the lowest, because the sidecar gives the work to the pod with
+  the lowest IP
+
+The scenarios walk one replica set through a lifecycle in order - bootstrap, host normalization,
+reaping a dead member, re-adding it - so they share state by design and must not be reordered or run
+in parallel.
+
+mongod refuses a remote `shutdown` when running without auth, so failure injection goes through a
+killswitch file on a volume shared with mongo-2, whose mongod runs under a wrapper that kills it and
+holds it down for 60s. Both grace periods (`MONGODB_UNHEALTHY_SECONDS`, `MONGODB_STARTUP_GRACE_SECONDS`)
+are pinned low in `vitest.integration.config.mts`: which one applies to a killed member depends on
+whether mongod still reports a `lastHeartbeatRecv` for it, which it does inconsistently.
+
+Not covered yet: authenticated connections (needs a keyfile, and the localhost exception makes
+bootstrapping one awkward while the sidecar is the thing doing `replSetInitiate`), TLS, and configsvr
+replica sets.
+
 ## Debugging
 
 TODO: Instructions for cloning, mounting and watching
 
 ## Still to do
 
-- Add tests!
 - Add to circleCi
 - Alter k8s call so that we don't have to filter in memory

--- a/docker-compose.itest.yml
+++ b/docker-compose.itest.yml
@@ -1,0 +1,104 @@
+# Integration test harness: three real mongods plus the sidecar under test.
+#
+# The sidecar's world is not just "a mongo" - it connects to its own mongod on 127.0.0.1, identifies
+# itself by its local IP, and writes member hosts as Kubernetes pod FQDNs that every mongod has to be
+# able to resolve. So:
+#   - the test runner shares mongo-0's network namespace (network_mode: service:mongo-0), which is
+#     exactly how the sidecar sits next to mongod in a pod: 127.0.0.1 is mongo-0 and getLocalIp()
+#     returns mongo-0's address
+#   - each mongod carries its pod FQDN as a network alias, so a real replSetReconfig with FQDN hosts
+#     resolves and heartbeats work
+#   - the addresses are static, and mongo-0's is the lowest: the sidecar elects the pod with the
+#     lowest IP to do the work, and the sidecar under test is the one in mongo-0
+#
+# The subnet is pinned but deliberately outside Docker's default pools (172.17-172.31, 192.168.x),
+# which are where an existing network is likely to already sit. Change it if it clashes locally.
+#
+# mongo-2 is the failure-injection node. mongod refuses a remote shutdown command when running
+# without auth ("shutdown must run from localhost"), and the tests have no localhost there - so
+# instead its mongod runs under a wrapper watching a killswitch file on a volume the tests share.
+# Touching the file kills mongod for real, and the wrapper keeps it down well past
+# MONGODB_UNHEALTHY_SECONDS before restarting it, making both the reap and the re-add observable
+# without the tests needing control of the Docker daemon.
+
+networks:
+  rs:
+    ipam:
+      config:
+        - subnet: 10.123.45.0/24
+
+volumes:
+  killswitch:
+
+services:
+  mongo-0:
+    image: mongo:7
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    networks:
+      rs:
+        aliases: ["db-0.db.test-ns.svc.cluster.local"]
+        ipv4_address: 10.123.45.10
+
+  mongo-1:
+    image: mongo:7
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    networks:
+      rs:
+        aliases: ["db-1.db.test-ns.svc.cluster.local"]
+        ipv4_address: 10.123.45.11
+
+  mongo-2:
+    image: mongo:7
+    command:
+      - bash
+      - -c
+      - |
+        rm -f /killswitch/kill
+        while true; do
+          mongod --replSet rs0 --bind_ip_all &
+          mongod_pid=$$!
+          while [ ! -f /killswitch/kill ]; do sleep 0.5; done
+          rm -f /killswitch/kill
+          echo "killswitch tripped, killing mongod for 60s"
+          kill -9 $$mongod_pid
+          wait $$mongod_pid || true
+          # Long enough that mongod noticing (~10s) plus the sidecar's grace period cannot race the
+          # restart, so the reap is deterministic rather than a matter of timing
+          sleep 60
+          echo "restarting mongod"
+        done
+    volumes:
+      - killswitch:/killswitch
+    networks:
+      rs:
+        aliases: ["db-2.db.test-ns.svc.cluster.local"]
+        ipv4_address: 10.123.45.12
+
+  tests:
+    image: node:24
+    working_dir: /app
+    # Anonymous volume shields the container's node_modules from the host's, which may have been
+    # installed for another platform
+    volumes:
+      - .:/app
+      - /app/node_modules
+      - killswitch:/killswitch
+    network_mode: "service:mongo-0"
+    depends_on:
+      - mongo-0
+      - mongo-1
+      - mongo-2
+    # VITEST_ARGS is how the junit reporter gets switched on, the same way the test-teamcity script
+    # does it for the unit tests - see the test:integration-teamcity script in package.json.
+    #
+    # Any report lands in the bind-mounted checkout, written by root inside the container. Hand it back
+    # to whoever owns the checkout, or a CI agent running as anything but root cannot clean its own
+    # workspace afterwards.
+    command:
+      - bash
+      - -c
+      - |
+        npm ci && npx vitest run --config vitest.integration.config.mts $$VITEST_ARGS
+        status=$$?
+        chown -R $$(stat -c %u:%g /app) /app/reports 2>/dev/null || true
+        exit $$status

--- a/docker-compose.itest.yml
+++ b/docker-compose.itest.yml
@@ -75,13 +75,13 @@ services:
         ipv4_address: 10.123.45.12
 
   tests:
-    image: node:24
-    working_dir: /app
-    # Anonymous volume shields the container's node_modules from the host's, which may have been
-    # installed for another platform
+    # The checkout and its node_modules are baked into the image rather than bind-mounted, so the
+    # harness does not care whether the docker daemon shares a filesystem with the client - see
+    # Dockerfile.itest for the full reasoning.
+    build:
+      context: .
+      dockerfile: Dockerfile.itest
     volumes:
-      - .:/app
-      - /app/node_modules
       - killswitch:/killswitch
     network_mode: "service:mongo-0"
     depends_on:
@@ -89,16 +89,9 @@ services:
       - mongo-1
       - mongo-2
     # VITEST_ARGS is how the junit reporter gets switched on, the same way the test-teamcity script
-    # does it for the unit tests - see the test:integration-teamcity script in package.json.
-    #
-    # Any report lands in the bind-mounted checkout, written by root inside the container. Hand it back
-    # to whoever owns the checkout, or a CI agent running as anything but root cannot clean its own
-    # workspace afterwards.
+    # does it for the unit tests. Any report stays inside the container at /app/reports; the
+    # test:integration-teamcity script copies it out with docker cp afterwards.
     command:
       - bash
       - -c
-      - |
-        npm ci && npx vitest run --config vitest.integration.config.mts $$VITEST_ARGS
-        status=$$?
-        chown -R $$(stat -c %u:%g /app) /app/reports 2>/dev/null || true
-        exit $$status
+      - npx vitest run --config vitest.integration.config.mts $$VITEST_ARGS

--- a/docker-compose.itest.yml
+++ b/docker-compose.itest.yml
@@ -81,6 +81,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.itest
+      # npm clean-install has to reach registry.npmjs.org from inside the build. The default build
+      # network gave "EAI_AGAIN registry.npmjs.org" on the CI agent - the build container could not
+      # resolve, while the daemon's host could - so the build borrows the host's network namespace and
+      # therefore its resolver. This only applies to the build; the running container still joins
+      # mongo-0's namespace via network_mode below.
+      network: host
     volumes:
       - killswitch:/killswitch
     network_mode: "service:mongo-0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo-k8s-sidecar",
-  "version": "0.17.5",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo-k8s-sidecar",
-      "version": "0.17.5",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
@@ -21,7 +21,8 @@
         "eslint-plugin-prettier": "^5.5.6",
         "prettier": "3.9.6",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.65.0"
+        "typescript-eslint": "^8.65.0",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": "^24.0.0",
@@ -222,6 +223,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@jsep-plugin/assignment": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
@@ -279,6 +287,16 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
@@ -291,6 +309,294 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -592,6 +898,119 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -646,6 +1065,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -803,6 +1232,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -814,6 +1253,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -863,6 +1309,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -903,6 +1359,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1153,6 +1616,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1170,6 +1643,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1289,6 +1772,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1581,6 +2079,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1595,6 +2366,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1714,6 +2495,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1780,6 +2580,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/once": {
@@ -1874,10 +2688,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1885,6 +2713,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -1951,6 +2808,39 @@
       "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
       "license": "MIT"
     },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -1986,6 +2876,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -2025,6 +2922,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -2033,6 +2940,20 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-buffers": {
       "version": "3.0.3",
@@ -2104,10 +3025,27 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2119,6 +3057,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -2213,6 +3161,174 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -2249,6 +3365,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "format:check": "prettier . --check",
     "test": "vitest run",
     "test-teamcity": "vitest run --reporter=default --reporter=junit",
-    "test:integration": "docker compose -f docker-compose.itest.yml run --rm tests",
-    "test:integration-teamcity": "docker compose -f docker-compose.itest.yml run --rm -e VITEST_ARGS=\"--reporter=default --reporter=junit\" tests",
+    "test:integration": "docker compose -f docker-compose.itest.yml run --rm --build tests",
+    "test:integration-teamcity": "node scripts/itest-teamcity.mts",
     "test:integration:down": "docker compose -f docker-compose.itest.yml down -v --remove-orphans"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format:check": "prettier . --check",
     "test": "vitest run",
     "test-teamcity": "vitest run --reporter=default --reporter=junit",
-    "test:integration": "docker compose -f docker-compose.itest.yml run --rm --build tests",
+    "test:integration": "docker compose -f docker-compose.itest.yml build tests && docker compose -f docker-compose.itest.yml run --rm tests",
     "test:integration-teamcity": "node scripts/itest-teamcity.mts",
     "test:integration:down": "docker compose -f docker-compose.itest.yml down -v --remove-orphans"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-k8s-sidecar",
-  "version": "0.17.5",
+  "version": "0.18.0",
   "description": "Kubernetes sidecar for MongoDB",
   "main": "src/index.ts",
   "type": "module",
@@ -8,12 +8,16 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc -p tsconfig.build.json",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "watch": "tsc -w"
+    "test": "vitest run",
+    "test-teamcity": "vitest run --reporter=default --reporter=junit",
+    "test:integration": "docker compose -f docker-compose.itest.yml run --rm tests",
+    "test:integration-teamcity": "docker compose -f docker-compose.itest.yml run --rm -e VITEST_ARGS=\"--reporter=default --reporter=junit\" tests",
+    "test:integration:down": "docker compose -f docker-compose.itest.yml down -v --remove-orphans"
   },
   "engines": {
     "node": "^24.0.0",
@@ -32,6 +36,7 @@
     "eslint-plugin-prettier": "^5.5.6",
     "prettier": "3.9.6",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.65.0"
+    "typescript-eslint": "^8.65.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/scripts/itest-teamcity.mts
+++ b/scripts/itest-teamcity.mts
@@ -35,16 +35,18 @@ const dockerQuietly = (args: string[]): void => {
 // A container left behind by a killed run would make --name collide
 dockerQuietly(["rm", "-f", CONTAINER]);
 
-const testStatus = docker([
-  ...COMPOSE,
-  "run",
-  "--build",
-  "--name",
-  CONTAINER,
-  "-e",
-  "VITEST_ARGS=--reporter=default --reporter=junit",
-  "tests",
-]);
+// The image is built as its own step, before anything brings the stack up, because `run --build` builds
+// with the dependencies already started - and by then the rs network exists with its pinned
+// 10.123.45.0/24 subnet. The build shares the host's network namespace (see build.network in the compose
+// file), so that route is in scope while npm talks to the registry, and on CI it swallowed the traffic:
+// npm resolved the registry fine and then sat in a read until ETIMEDOUT. Building first keeps the two
+// apart. Note the stack's own teardown at the end is what makes the *next* run's build safe too.
+const buildStatus = docker([...COMPOSE, "build", "tests"]);
+
+const testStatus =
+  buildStatus === 0 ?
+    docker([...COMPOSE, "run", "--name", CONTAINER, "-e", "VITEST_ARGS=--reporter=default --reporter=junit", "tests"])
+  : buildStatus;
 
 // A run that died before vitest wrote anything has no report to copy, and that must not mask the test
 // result

--- a/scripts/itest-teamcity.mts
+++ b/scripts/itest-teamcity.mts
@@ -1,5 +1,11 @@
-// Runs the integration harness the way CI needs it: junit reporter on, and the report pulled back out
-// of the container into the checkout so TeamCity can pick it up.
+// Runs the integration harness the way CI needs it: junit reporter on, the report pulled back out of the
+// container into the checkout so TeamCity can pick it up, and the compose stack torn down afterwards -
+// all under one exit code.
+//
+// The teardown lives here rather than as a second line in the TeamCity build step on purpose. A bash step
+// without `set -e` reports the status of its *last* command, so a "run tests; tear down" step is always
+// green: the teardown succeeds even when the tests never ran. Everything below is best-effort except the
+// test run itself, whose status is the only thing this script exits with.
 //
 // The report cannot simply land in a bind-mounted directory. On a containerised build agent the docker
 // daemon does not share the agent's filesystem, so a bind mount of the checkout silently resolves to an
@@ -15,26 +21,37 @@ import { mkdirSync } from "node:fs";
 const COMPOSE = ["compose", "-f", "docker-compose.itest.yml"];
 const CONTAINER = "mongo-k8s-sidecar-itest-runner";
 
-const docker = (args: string[], { check = true }: { check?: boolean } = {}): number => {
+const docker = (args: string[]): number => {
   const { status } = spawnSync("docker", args, { stdio: "inherit" });
-  if (check && status !== 0) {
-    process.exit(status ?? 1);
-  }
   return status ?? 1;
 };
 
+// Housekeeping whose failure says nothing about the tests: "no such container" on a clean agent is the
+// normal case, so its noise stays out of the build log
+const dockerQuietly = (args: string[]): void => {
+  spawnSync("docker", args, { stdio: "ignore" });
+};
+
 // A container left behind by a killed run would make --name collide
-docker(["rm", "-f", CONTAINER], { check: false });
+dockerQuietly(["rm", "-f", CONTAINER]);
 
-const testStatus = docker(
-  [...COMPOSE, "run", "--build", "--name", CONTAINER, "-e", "VITEST_ARGS=--reporter=default --reporter=junit", "tests"],
-  { check: false },
-);
+const testStatus = docker([
+  ...COMPOSE,
+  "run",
+  "--build",
+  "--name",
+  CONTAINER,
+  "-e",
+  "VITEST_ARGS=--reporter=default --reporter=junit",
+  "tests",
+]);
 
-// Best-effort: a run that died before vitest wrote anything has no report, and that must not mask the
-// test result
+// A run that died before vitest wrote anything has no report to copy, and that must not mask the test
+// result
 mkdirSync("reports", { recursive: true });
-docker(["cp", `${CONTAINER}:/app/reports/.`, "reports"], { check: false });
-docker(["rm", "-f", CONTAINER], { check: false });
+dockerQuietly(["cp", `${CONTAINER}:/app/reports/.`, "reports"]);
+dockerQuietly(["rm", "-f", CONTAINER]);
+
+docker([...COMPOSE, "down", "-v", "--remove-orphans"]);
 
 process.exit(testStatus);

--- a/scripts/itest-teamcity.mts
+++ b/scripts/itest-teamcity.mts
@@ -1,0 +1,40 @@
+// Runs the integration harness the way CI needs it: junit reporter on, and the report pulled back out
+// of the container into the checkout so TeamCity can pick it up.
+//
+// The report cannot simply land in a bind-mounted directory. On a containerised build agent the docker
+// daemon does not share the agent's filesystem, so a bind mount of the checkout silently resolves to an
+// empty directory on the daemon side (see Dockerfile.itest). docker cp goes over the socket, so it works
+// regardless of where the daemon is - but it needs a container that still exists after the run, hence
+// --name plus an explicit rm instead of --rm.
+//
+// Node runs this .mts directly by stripping the types - no build step.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+
+const COMPOSE = ["compose", "-f", "docker-compose.itest.yml"];
+const CONTAINER = "mongo-k8s-sidecar-itest-runner";
+
+const docker = (args: string[], { check = true }: { check?: boolean } = {}): number => {
+  const { status } = spawnSync("docker", args, { stdio: "inherit" });
+  if (check && status !== 0) {
+    process.exit(status ?? 1);
+  }
+  return status ?? 1;
+};
+
+// A container left behind by a killed run would make --name collide
+docker(["rm", "-f", CONTAINER], { check: false });
+
+const testStatus = docker(
+  [...COMPOSE, "run", "--build", "--name", CONTAINER, "-e", "VITEST_ARGS=--reporter=default --reporter=junit", "tests"],
+  { check: false },
+);
+
+// Best-effort: a run that died before vitest wrote anything has no report, and that must not mask the
+// test result
+mkdirSync("reports", { recursive: true });
+docker(["cp", `${CONTAINER}:/app/reports/.`, "reports"], { check: false });
+docker(["rm", "-f", CONTAINER], { check: false });
+
+process.exit(testStatus);

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ interface KubeConfig {
   labelSelector: string;
   mongoServiceName: string;
   namespace: string;
+  normalizeMemberHosts: boolean;
 }
 
 interface MongoAuthConfig {
@@ -31,7 +32,9 @@ interface MongoConfig {
 
   isConfigSvr: boolean;
 
+  forceReconfigGraceSeconds: number;
   loopSleepSeconds: number;
+  startupGraceSeconds: number;
   unhealthySeconds: number;
 }
 
@@ -58,6 +61,13 @@ const isConfigRS = (): boolean => {
   return configSvrBool;
 };
 
+const normalizeMemberHosts = (): boolean => {
+  const normalize = (process.env.KUBE_NORMALIZE_MEMBER_HOSTS || "").trim().toLowerCase();
+
+  // Defaults on, so it's the off switch we have to recognise - in the same spellings isConfigRS accepts
+  return !/^(?:n|no|false|0)$/i.test(normalize);
+};
+
 const loadConfig = (): Config => {
   return {
     kube: {
@@ -66,13 +76,16 @@ const loadConfig = (): Config => {
       labelSelector: process.env.MONGO_SIDECAR_POD_LABELS || "app=solidatus-db",
       mongoServiceName: process.env.KUBE_MONGO_SERVICE_NAME || "db",
       namespace: process.env.KUBE_NAMESPACE || "default",
+      normalizeMemberHosts: normalizeMemberHosts(),
     },
     mongo: {
       auth: loadMongoAuthConfig(),
+      forceReconfigGraceSeconds: parseInt(process.env.MONGODB_FORCE_RECONFIG_GRACE_SECONDS || "30"),
       isConfigSvr: isConfigRS(),
 
       loopSleepSeconds: parseInt(process.env.MONGODB_LOOP_SLEEP_SECONDS || "5"),
       port: parseInt(process.env.MONGODB_PORT || "27017"),
+      startupGraceSeconds: parseInt(process.env.MONGODB_STARTUP_GRACE_SECONDS || "300"),
       tls: process.env.MONGODB_TLS === "true",
 
       tlsAllowInvalidCertificates: process.env.MONGODB_TLS_ALLOW_INVALID_CERTIFICATES === "true",

--- a/src/k8s.ts
+++ b/src/k8s.ts
@@ -4,23 +4,35 @@ import { config } from "./config.js";
 
 import type { Cluster, V1Pod } from "@kubernetes/client-node";
 
-const kc = new KubeConfig();
-kc.loadFromDefault();
+// Built on first use rather than at import: loadFromDefault() needs a kubeconfig on disk or the
+// in-cluster service account, so doing it at import makes this module unimportable anywhere else -
+// including from a test that only wants the pod list stubbed.
+let k8sApi: CoreV1Api | undefined;
 
-if (config.kube.clusterSkipTLSVerify) {
-  // Cluster.skipTLSVerify is readonly. Let's respect it and create new cluster objects.
-  // Assigning to KubeConfig.clusters appears to be the way, same as the 'loadFromCluster' in config.js of the k8s client lib.
-  kc.clusters = kc.clusters.map<Cluster>((cluster) => ({
-    ...cluster,
-    skipTLSVerify: true,
-  }));
-}
+const getApi = (): CoreV1Api => {
+  if (k8sApi) {
+    return k8sApi;
+  }
 
-const k8sApi = kc.makeApiClient(CoreV1Api);
+  const kc = new KubeConfig();
+  kc.loadFromDefault();
+
+  if (config.kube.clusterSkipTLSVerify) {
+    // Cluster.skipTLSVerify is readonly. Let's respect it and create new cluster objects.
+    // Assigning to KubeConfig.clusters appears to be the way, same as the 'loadFromCluster' in config.js of the k8s client lib.
+    kc.clusters = kc.clusters.map<Cluster>((cluster) => ({
+      ...cluster,
+      skipTLSVerify: true,
+    }));
+  }
+
+  k8sApi = kc.makeApiClient(CoreV1Api);
+  return k8sApi;
+};
 
 const getMongoPods = async (): Promise<V1Pod[]> => {
   const kubeConfig = config.kube;
-  const podList = await k8sApi.listNamespacedPod({
+  const podList = await getApi().listNamespacedPod({
     labelSelector: kubeConfig.labelSelector,
     namespace: kubeConfig.namespace,
   });

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,15 @@
 /* eslint-disable no-console */
 const getDate = (): string => new Date().toISOString();
 
+// Read straight from the environment rather than through config.js, which imports this module.
+const debugEnabled = process.env.LOG_DEBUG === "true";
+
 const log = {
+  debug: (msg: string, ...optionalParams: unknown[]) => {
+    if (debugEnabled) {
+      console.log(`[${getDate()}] DEBUG: ${msg}`, ...optionalParams);
+    }
+  },
   error: (msg: string, ...optionalParams: unknown[]) =>
     console.error(`[${getDate()}] ERROR: ${msg}`, ...optionalParams),
   info: (msg: string, ...optionalParams: unknown[]) => console.log(`[${getDate()}] INFO: ${msg}`, ...optionalParams),

--- a/src/mongo.ts
+++ b/src/mongo.ts
@@ -1,21 +1,71 @@
-import { Db, MongoClient } from "mongodb";
+import { Db, MongoClient, MongoServerError } from "mongodb";
 
 import { config } from "./config.js";
 import { log } from "./log.js";
 import { ReplSetConfig, ReplSetStatus } from "./types.js";
 import { range, sleep } from "./utils.js";
 
-let mongoClient: MongoClient | null = null;
+// Keyed by host: the local mongod and every peer we probe need their own connection. A single shared
+// client would answer peer queries from whichever host connected first, which silently turns
+// "is any peer already in a replica set?" into "am I in a replica set?"
+const mongoClients = new Map<string, MongoClient>();
 
-const getDb = async (host: string = "127.0.0.1"): Promise<Db> => {
-  if (mongoClient === null) {
-    mongoClient = await createMongoClient(host);
+// Probing a peer must not stall the work loop: a pod that is Running as far as the API is concerned
+// but whose mongod is unreachable would otherwise hold us for the driver's 30s default. Only used
+// for peer probes - the local connection keeps the default, as it has to survive reconfigs.
+const probeTimeoutMs = 3000;
+
+const getDb = async (host: string = "127.0.0.1", timeoutMs?: number): Promise<Db> => {
+  let mongoClient = mongoClients.get(host);
+  if (mongoClient === undefined) {
+    // Nothing is cached until connect() resolves, so a failed connection is retried next loop
+    mongoClient = await createMongoClient(host, timeoutMs);
+    mongoClients.set(host, mongoClient);
   }
 
   return mongoClient.db();
 };
 
-const createMongoClient = async (host: string): Promise<MongoClient> => {
+const closeDb = async (host: string): Promise<void> => {
+  const mongoClient = mongoClients.get(host);
+  if (mongoClient === undefined) {
+    return;
+  }
+
+  mongoClients.delete(host);
+  try {
+    await mongoClient.close();
+  } catch (err) {
+    log.debug(`Failed to close MongoDB client for ${host}`, err);
+  }
+};
+
+// The cache is module level and outlives any one caller, so anything that wants to let the process
+// (or a test file) end has to drop every connection, not just the ones it opened itself.
+const closeAllDbs = async (): Promise<void> => {
+  await Promise.all([...mongoClients.keys()].map(async (host) => await closeDb(host)));
+};
+
+// The local connection is opened under getDb's default host, which is no pod's address, so it is
+// never in a caller's list of live hosts and has to be spared by name.
+const localHost = "127.0.0.1";
+
+// A successful probe leaves its client cached, and pods do not come back on the same IP - so without
+// this the cache grows by one client per pod restart for the life of the process, each with a
+// monitor still heartbeating an address nothing answers on. Callers pass the hosts they would probe
+// this cycle, in the same spelling they probe with, and everything else is dropped.
+const pruneDbCache = async (liveHosts: string[]): Promise<void> => {
+  const keep = new Set([...liveHosts, localHost]);
+  const stale = [...mongoClients.keys()].filter((host) => !keep.has(host));
+  if (stale.length === 0) {
+    return;
+  }
+
+  log.info(`Closing cached MongoDB connections to hosts that are no longer running`, { hosts: stale });
+  await Promise.all(stale.map(async (host) => await closeDb(host)));
+};
+
+const createMongoClient = async (host: string, timeoutMs?: number): Promise<MongoClient> => {
   const mongoConfig = config.mongo;
   const authConfig = mongoConfig.auth;
 
@@ -33,10 +83,11 @@ const createMongoClient = async (host: string): Promise<MongoClient> => {
     tls: mongoConfig.tls,
     tlsAllowInvalidCertificates: mongoConfig.tlsAllowInvalidCertificates,
     tlsAllowInvalidHostnames: mongoConfig.tlsAllowInvalidHostnames,
+    ...(timeoutMs === undefined ? {} : { connectTimeoutMS: timeoutMs, serverSelectionTimeoutMS: timeoutMs }),
   });
 
   // test the connection
-  log.info("Connecting to MongoDB");
+  log.info(`Connecting to MongoDB at ${host}`);
   await mongoClient.connect();
 
   return mongoClient;
@@ -51,8 +102,16 @@ const replSetGetStatus = async (db: Db): Promise<ReplSetStatus> => {
 };
 
 const replSetReconfig = async (db: Db, rsConfig: ReplSetConfig, force: boolean = false): Promise<void> => {
-  log.info("replSetReconfig", rsConfig);
   rsConfig.version++;
+
+  // Log after the increment so the version here is the one being written, and keep it to the parts
+  // that change - the settings block is static noise on a loop that reconfigs every few seconds
+  log.info("replSetReconfig", {
+    force: force,
+    members: rsConfig.members.map((m) => `${m._id}: ${m.host}`),
+    version: rsConfig.version,
+  });
+  log.debug("replSetReconfig full config", rsConfig);
 
   // MongoDB gets fussy if the command name (replSetReconfig) is not the first key in the object
   // eslint-disable-next-line perfectionist/sort-objects
@@ -97,6 +156,28 @@ const addNewReplSetMembers = async (db: Db, newAddrs: string[], deadAddrs: strin
   await replSetReconfig(db, rsConfig, force);
 };
 
+// Returns whether a reconfig actually happened - the caller skips the rest of its cycle for a rename,
+// so a no-op here must not cost it that cycle.
+const renameReplSetMember = async (db: Db, from: string, to: string, force: boolean = false): Promise<boolean> => {
+  const rsConfig = await replSetGetConfig(db);
+
+  const member = rsConfig.members.find((m) => m.host === from);
+  if (!member) {
+    log.warn(`Member ${from} is no longer in the replica set, not renaming`);
+    return false;
+  }
+  if (rsConfig.members.some((m) => m.host === to)) {
+    log.warn(`Member ${to} already exists in the replica set, not renaming ${from}`);
+    return false;
+  }
+
+  log.info(`Renaming member ${from} to ${to}`);
+  member.host = to;
+
+  await replSetReconfig(db, rsConfig, force);
+  return true;
+};
+
 const addNewMembers = (rsConfig: ReplSetConfig, addrs: string[]): void => {
   if (addrs.length === 0) {
     return;
@@ -106,15 +187,9 @@ const addNewMembers = (rsConfig: ReplSetConfig, addrs: string[]): void => {
   const memberIds = rsConfig.members.map((m) => m._id);
 
   for (const addr of addrs) {
-    // search for the next available member ID (max 255)
-    newMemberId = range(newMemberId, 256).find((i) => !memberIds.includes(i)) ?? -1;
-    if (newMemberId === -1) {
-      throw new Error("No available member ID");
-    }
-    memberIds.push(newMemberId);
-
     // We can get a race condition where the member config has been updated since we created the list of addresses to add
-    // so we do another loop to make sure we don't add duplicates
+    // so we do another loop to make sure we don't add duplicates. Checked before claiming an ID, or
+    // a skipped address takes an ID with it.
     let exists = false;
     for (const member of rsConfig.members) {
       if (member.host === addr) {
@@ -126,6 +201,13 @@ const addNewMembers = (rsConfig: ReplSetConfig, addrs: string[]): void => {
     if (exists) {
       continue;
     }
+
+    // search for the next available member ID (max 255)
+    newMemberId = range(newMemberId, 256).find((i) => !memberIds.includes(i)) ?? -1;
+    if (newMemberId === -1) {
+      throw new Error("No available member ID");
+    }
+    memberIds.push(newMemberId);
 
     const cfg = {
       _id: newMemberId,
@@ -144,14 +226,64 @@ const removeDeadMembers = (rsConfig: ReplSetConfig, addrs: string[]): void => {
 };
 
 const isInReplSet = async (ip: string): Promise<boolean> => {
-  const db = await getDb(ip);
-
   try {
+    // getDb has to be inside the try: connecting to a peer can fail, and a single unreachable pod
+    // must not take down the caller's Promise.all and with it the whole work loop iteration
+    const db = await getDb(ip, probeTimeoutMs);
     const rsConfig = await replSetGetConfig(db);
     return !!rsConfig;
-  } catch {
+  } catch (err) {
+    if (err instanceof MongoServerError) {
+      // NotYetInitialized: the server answered, it just isn't in a replica set. The connection is
+      // fine, so keep it cached - during bootstrap this is the expected answer from every peer,
+      // every loop.
+      if (err.code === 94) {
+        return false;
+      }
+
+      // Unauthorized and AuthenticationFailed are not a fact about the peer at all, they are a fact
+      // about our own configuration - wrong credentials, or an authDb that doesn't exist. That answer
+      // never changes on its own, and since the user is normally created after the replica set exists,
+      // the condition cannot clear by itself either: bootstrap of a new set never happens until
+      // someone fixes the config. The answer is still in-set, because guessing "not in a set" here is
+      // what splits the brain - but this line has to name the cause rather than read as a peer problem.
+      if (err.code === 13 || err.code === 18) {
+        log.error(
+          `Replica set probe of ${ip} could not authenticate - check MONGODB_USERNAME, MONGODB_PASSWORD and ` +
+            `MONGODB_AUTHDB. Treating the peer as in-set, so this sidecar will not initiate a replica set while ` +
+            `this lasts, and a set that does not exist yet will not be created at all`,
+          err,
+        );
+        return true;
+      }
+
+      // Any other server side error (a transient state change, an unexpected refusal) leaves
+      // the peer's membership unknown. Report it as in-set: the caller only uses a unanimous "no"
+      // to elect itself for replSetInitiate, and initiating against a set that already exists
+      // splits the brain. A stalled bootstrap is recoverable, a second replica set is not.
+      //
+      // Logged as an error rather than a warning for the same reason as the auth case above: if this
+      // does turn out to be a state the peer never leaves, this is the only line that says why.
+      log.error(`Replica set probe of ${ip} returned an unexpected server error, assuming in-set`, err);
+      return true;
+    }
+
+    // Anything else is a connection level failure. Pod IPs get recycled onto other pods, so drop
+    // the client rather than reusing a connection to a host that may not be that pod any more.
+    log.debug(`Replica set probe of ${ip} failed`, err);
+    await closeDb(ip);
     return false;
   }
 };
 
-export { addNewReplSetMembers, getDb, initReplSet, isInReplSet, replSetGetStatus };
+export {
+  addNewReplSetMembers,
+  closeAllDbs,
+  getDb,
+  initReplSet,
+  isInReplSet,
+  pruneDbCache,
+  renameReplSetMember,
+  replSetGetConfig,
+  replSetGetStatus,
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,13 +26,17 @@ type ReplSetMemberState =
 /* eslint-enable perfectionist/sort-union-types */
 
 type ReplSetStatus = {
-  members: ReplSetStatusMember[];
+  // A mongod that has been removed from the set still answers replSetGetStatus, but with only a
+  // subset of the fields - members among the ones it leaves out.
+  members?: ReplSetStatusMember[];
+  myState?: number;
   set: string;
 };
 
 type ReplSetStatusMember = {
   _id: number;
   health: number;
+  lastHeartbeatMessage?: string;
   lastHeartbeatRecv?: Date;
   name: string;
   self: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,12 +25,14 @@ const getPodIp = (pod: V1Pod): string | undefined => {
   return pod.status?.podIP ? `${pod.status?.podIP}:${config.mongo.port}` : undefined;
 };
 
+const getPodHostname = (pod: undefined | V1Pod): string | undefined => pod?.spec?.hostname ?? pod?.metadata?.name;
+
 const getPodFqdn = (pod: undefined | V1Pod): string | undefined => {
-  const hostname = pod?.spec?.hostname ?? pod?.metadata?.name;
+  const hostname = getPodHostname(pod);
 
   return hostname ?
       `${hostname}.${config.kube.mongoServiceName}.${config.kube.namespace}.svc.${config.kube.clusterDomain}:${config.mongo.port}`
     : undefined;
 };
 
-export { getHostname, getLocalIp, getPodFqdn, getPodIp, range, sleep };
+export { getHostname, getLocalIp, getPodFqdn, getPodHostname, getPodIp, range, sleep };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3,9 +3,18 @@ import { Db, MongoServerError } from "mongodb";
 import { config } from "./config.js";
 import { getMongoPods } from "./k8s.js";
 import { log } from "./log.js";
-import { addNewReplSetMembers, getDb, initReplSet, isInReplSet, replSetGetStatus } from "./mongo.js";
+import {
+  addNewReplSetMembers,
+  getDb,
+  initReplSet,
+  isInReplSet,
+  pruneDbCache,
+  renameReplSetMember,
+  replSetGetConfig,
+  replSetGetStatus,
+} from "./mongo.js";
 import { ReplSetStatus, ReplSetStatusMember } from "./types.js";
-import { getLocalIp, getPodFqdn, getPodIp } from "./utils.js";
+import { getLocalIp, getPodFqdn, getPodHostname, getPodIp } from "./utils.js";
 
 import type { V1Pod } from "@kubernetes/client-node";
 
@@ -21,6 +30,10 @@ const init = (): void => {
   hostIpAndPort = `${hostIp}:${config.mongo.port}`;
 };
 
+// The one place a pod is turned into the host its probe connects to, so the connection cache and the
+// prune that empties it can never disagree about how a pod is spelled.
+const probeHost = (pod: V1Pod): string => pod.status?.podIP ?? "";
+
 const workloop = async (): Promise<void> => {
   if (!hostIp || !hostIpAndPort) {
     throw new Error("hostIp or hostIpAndPort not initialized");
@@ -34,6 +47,10 @@ const workloop = async (): Promise<void> => {
     if (runningPods.length === 0) {
       throw new Error("no running pods found");
     }
+
+    // Peer connections are cached and pods never come back on the same IP, so drop the ones no
+    // running pod answers on. Uses probeHost, the address the probes are actually keyed by.
+    await pruneDbCache(runningPods.map(probeHost));
 
     try {
       const status = await replSetGetStatus(db);
@@ -56,11 +73,22 @@ const workloop = async (): Promise<void> => {
   }
 };
 
-const inReplicaSet = async (db: Db, pods: V1Pod[], status: ReplSetStatus) => {
+const inReplicaSet = async (db: Db, pods: V1Pod[], status: ReplSetStatus, gate: ForceGate = forceReconfigGate) => {
   // If we're already in a rs and we ARE the primary, do the work of the primary instance (i.e. adding others)
   // If we're already in a rs and we ARE NOT the primary, just continue, nothing to do
   // If we're already in a rs and NO ONE is a primary, elect someone to do the work for a primary
+  //
+  // No members list means this mongod has been removed from the set (state REMOVED): it holds a
+  // config it isn't in, so it has no view of the set to act on and no standing to reconfig it.
+  // Nothing to do but wait - the set's own primary sees this pod missing and adds it back.
   const members = status.members;
+  if (!members) {
+    log.warn("Pod is not a member of the replica set it is configured for, waiting to be re-added", {
+      myState: status.myState,
+      set: status.set,
+    });
+    return;
+  }
 
   let primaryExists = false;
   for (const member of members) {
@@ -74,17 +102,57 @@ const inReplicaSet = async (db: Db, pods: V1Pod[], status: ReplSetStatus) => {
       break;
     }
   }
-  if (!primaryExists && podElection(pods)) {
-    log.info("Pod has been elected as secondary to do primary work");
-    await primaryWork(db, pods, members, true);
+  if (primaryExists) {
+    // With a primary in the set every reconfig carries mongod's own version check, so whatever made
+    // a forced one look necessary is over
+    clearForceGate(gate);
+    return;
   }
+
+  if (!podElection(pods)) {
+    return;
+  }
+
+  const now = new Date().getTime();
+  if (!forceReconfigAllowed(gate, now)) {
+    return;
+  }
+
+  log.info("Pod has been elected as secondary to do primary work");
+  markForced(gate, now);
+  await primaryWork(db, pods, members, true);
 };
 
-const primaryWork = async (db: Db, pods: V1Pod[], members: ReplSetStatusMember[], force: boolean): Promise<void> => {
+const primaryWork = async (
+  db: Db,
+  pods: V1Pod[],
+  members: ReplSetStatusMember[],
+  force: boolean,
+  tracker: UnhealthyTracker = unhealthyTracker,
+): Promise<void> => {
+  const addrDead = addrToRemoveLoop(members, tracker);
+
+  // A member host has to name one specific mongod and resolve from outside this namespace, so the
+  // pod FQDN is the only correct form. Converge on it before adding anything, one member per loop,
+  // so a rename never shares a reconfig with an add or a remove.
+  //
+  // Reaping comes first though: a reconfig needs a majority of voting members reachable, so a dead
+  // member can block the rename indefinitely - and the early return below would then stop us ever
+  // reaping it. The two would wedge each other, in exactly the situation we most need to recover.
+  if (addrDead.length === 0 && config.kube.normalizeMemberHosts) {
+    const rename = memberToRename(pods, members);
+    if (rename) {
+      // Same force as the membership reconfig below: without a primary this pod is a secondary, and
+      // mongod rejects a non-forced reconfig there - which would throw before add & remove ever run
+      if (await renameReplSetMember(db, rename.from, rename.to, force)) {
+        return;
+      }
+    }
+  }
+
   // Loop over all the pods we have and see if any of them aren't in the current rs members array
   // Add them if not
-  const addrNew = addrToAddLoop(pods, members);
-  const addrDead = addrToRemoveLoop(members);
+  const addrNew = addrToAddLoop(pods, members, true);
 
   if (addrNew.length !== 0 || addrDead.length !== 0) {
     log.info("Addresses to add ", addrNew);
@@ -97,51 +165,151 @@ const primaryWork = async (db: Db, pods: V1Pod[], members: ReplSetStatusMember[]
 const notInReplicaSet = async (db: Db, pods: V1Pod[]): Promise<void> => {
   const testRequests = pods
     .filter((p) => p.status?.phase === "Running" && p.status?.podIP)
-    .map(async (p) => await isInReplSet(p.status?.podIP ?? ""));
+    .map(async (p) => await isInReplSet(probeHost(p)));
 
   const results = await Promise.all(testRequests);
   if (results.some((r) => r)) {
     return; // there's a ppd in a replica set
   }
 
-  if (podElection(pods)) {
-    log.info("Pod has been elected for replica set init");
-    const primary = pods[0];
-    const primaryFqdn = getPodFqdn(primary);
-    await initReplSet(db, primaryFqdn || hostIpAndPort!);
+  // The pod the election picked is the seed of the new set, and it is this pod - take the address from
+  // the winner itself rather than from wherever the list happens to be ordered
+  const elected = electedPod(pods);
+  if (elected?.status?.podIP !== hostIp) {
+    return;
   }
+
+  log.info("Pod has been elected for replica set init");
+  await initReplSet(db, getPodFqdn(elected) || hostIpAndPort!);
 };
 
-const invalidReplicaSet = async (db: Db, pods: V1Pod[]): Promise<void> => {
+const invalidReplicaSet = async (db: Db, pods: V1Pod[], gate: ForceGate = forceReconfigGate): Promise<void> => {
   log.info("Invalid replica set");
   if (!podElection(pods)) {
     log.info("Didn't win pod election, returning");
     return;
   }
 
-  log.info("Won pod election, forcing reinit");
-  const addrToAdd = addrToAddLoop(pods, []);
-  const addrToRemove = addrToRemoveLoop([]);
+  log.info("Won pod election, working out what a forced reinit would have to add");
 
-  await addNewReplSetMembers(db, addrToAdd, addrToRemove, true);
+  // replSetGetStatus is what failed here, so we have no member list from it - but the local config
+  // doc still reads, and a forced reconfig appends to it rather than replacing it. Compare against
+  // those hosts or we re-add every pod under a second name, duplicating each mongod.
+  const rsConfig = await replSetGetConfig(db);
+  const members = rsConfig.members.map((m) => ({ name: m.host }));
+
+  // Nothing to remove: the addresses we can't tie to a running pod are exactly the ones the remove
+  // loop reaps once status answers again, and a reconfig does one thing at a time.
+  //
+  // Error 93 also covers "this config does not contain us", and then the member list is non-empty
+  // but has no entry for this pod - so unlike the status path we can't take our own membership for
+  // granted and skip ourselves, or the pod driving the reinit is the one member it never adds.
+  const addrToAdd = addrToAddLoop(pods, members, false);
+
+  // A forced reconfig writes the same config back, which is not something error 93 recovers from - it
+  // only bumps the version. With nothing to add there is nothing here to fix, and reconfiguring
+  // anyway churns the version on every loop forever.
+  if (addrToAdd.length === 0) {
+    log.warn("Replica set config is invalid but every running pod is already a member, not reconfiguring", {
+      members: members.map((m) => m.name),
+    });
+    return;
+  }
+
+  // Error 93 is not a state that clears on its own, but a second sidecar racing this write turns one
+  // forced reconfig into a lost update - so the same fence applies here. Checked after the work above,
+  // which reconfigures nothing, so a loop with nothing to do doesn't consume the grace.
+  const now = new Date().getTime();
+  if (!forceReconfigAllowed(gate, now)) {
+    return;
+  }
+
+  markForced(gate, now);
+  await addNewReplSetMembers(db, addrToAdd, [], true);
+};
+
+// Sorts a copy: callers read this pod's own membership and the seed address out of the list they
+// passed, and an election must not be the thing that decides what order they see it in.
+const electedPod = (pods: V1Pod[]): undefined | V1Pod => {
+  // String sorting IP addresses doesn't provide a correct sort order but does provide a consistent sort order!
+  // And that's all we need to consistently elect the same pod
+  return pods.filter((p) => p.status?.podIP).sort((a, b) => a.status!.podIP!.localeCompare(b.status!.podIP!))[0];
 };
 
 const podElection = (pods: V1Pod[]): boolean => {
-  pods.sort((a, b) => {
-    const aIp = a.status?.podIP;
-    const bIp = b.status?.podIP;
-    if (!aIp || !bIp) {
-      return 0;
-    }
-    // String sorting IP addresses doesn't provide a correct sort order but does provide a consistent sort order!
-    // And that's all we need to consistently elect the same pod
-    return aIp.localeCompare(bIp);
-  });
-
-  return pods[0]?.status?.podIP === hostIp;
+  return electedPod(pods)?.status?.podIP === hostIp;
 };
 
-const addrToAddLoop = (pods: V1Pod[], members: ReplSetStatusMember[]): string[] => {
+// A pod can already be in the replica set under a spelling we didn't choose: a short service-scoped
+// name (pod.svc), a bare pod name, or an IP. Comparing the FQDN we'd generate against those misses
+// the match and we add the pod a second time - mongod then sees a member with its own member ID,
+// marks it unreachable, and we reap and re-add it on every loop.
+const isSameMemberAsPod = (memberName: string, pod: V1Pod): boolean => {
+  if (memberName === getPodFqdn(pod) || memberName === getPodIp(pod)) {
+    return true;
+  }
+
+  const podHostname = getPodHostname(pod);
+  if (!podHostname) {
+    return false;
+  }
+
+  const portSeparator = memberName.lastIndexOf(":");
+  if (portSeparator === -1 || memberName.slice(portSeparator + 1) !== String(config.mongo.port)) {
+    return false;
+  }
+
+  const labels = memberName.slice(0, portSeparator).split(".");
+  if (labels[0] !== podHostname) {
+    return false;
+  }
+
+  // A bare pod name carries nothing else to check. Anything longer names a service, and anything
+  // longer still a namespace - both have to agree with ours, otherwise it's a same-named pod behind
+  // another service or in another namespace.
+  if (labels.length > 1 && labels[1] !== config.kube.mongoServiceName) {
+    return false;
+  }
+
+  return labels.length < 3 || labels[2] === config.kube.namespace;
+};
+
+// Find one member whose host isn't the FQDN of the pod behind it. Two ways to tie a member to a
+// pod: mongod flags its own entry with self, whatever host name that entry uses - which is the only
+// handle we get on a name like a bare service name - and for the rest we fall back to matching the
+// host name against each pod.
+const memberToRename = (pods: V1Pod[], members: ReplSetStatusMember[]): undefined | { from: string; to: string } => {
+  const runningPods = pods.filter((p) => p.status?.phase === "Running");
+
+  for (const member of members) {
+    const pod =
+      member.self ?
+        runningPods.find((p) => getPodIp(p) === hostIpAndPort)
+      : runningPods.find((p) => isSameMemberAsPod(member.name, p));
+
+    const podFqdn = getPodFqdn(pod);
+    if (!podFqdn || member.name === podFqdn) {
+      continue;
+    }
+
+    // Another member already holds the FQDN - a duplicate of this pod under a second name. Leave it
+    // to the remove loop to reap, then the rename has somewhere to go.
+    if (members.some((m) => m.name === podFqdn)) {
+      continue;
+    }
+
+    return { from: member.name, to: podFqdn };
+  }
+
+  return undefined;
+};
+
+// Members here only need a host name, so this takes the common shape of a status member and a config
+// member - the forced-reinit path has only the latter.
+// selfIsMember says whether this pod can be assumed to already be in the given members list, however
+// its entry is spelled. Only replSetGetStatus answering proves that; a config doc read off disk does
+// not, so that caller passes false and takes the name matching below for its answer.
+const addrToAddLoop = (pods: V1Pod[], members: { name: string }[], selfIsMember: boolean): string[] => {
   const addrs: string[] = [];
   for (const pod of pods) {
     if (pod.status?.phase !== "Running") {
@@ -150,11 +318,25 @@ const addrToAddLoop = (pods: V1Pod[], members: ReplSetStatusMember[]): string[] 
 
     const podIp = getPodIp(pod);
     const podFqdn = getPodFqdn(pod);
-    const podInRs = members.some((m) => m.name === podFqdn || m.name === podIp);
+
+    // Our own mongod answered with a non-empty members list, so it is a member under whatever host
+    // name that config happens to use - even one we can't recognise, like a bare service name. Adding
+    // our own address again would duplicate it.
+    // An empty list means there is nothing to be a member of, so we do have to add ourselves.
+    if (selfIsMember && members.length > 0 && podIp === hostIpAndPort) {
+      continue;
+    }
+
+    const podInRs = members.some((m) => isSameMemberAsPod(m.name, pod));
 
     if (!podInRs) {
       const addr = podFqdn || podIp;
       if (addr) {
+        // Name the pod and what we compared against: if the pod is in fact already a member under a
+        // host name we failed to recognise, this is the line that shows it
+        log.info(`Pod ${pod.metadata?.name} is not a member, adding ${addr}`, {
+          existingMembers: members.map((m) => m.name),
+        });
         addrs.push(addr);
       } else {
         log.warn(`Could not find address for a pod, skipping`);
@@ -164,13 +346,144 @@ const addrToAddLoop = (pods: V1Pod[], members: ReplSetStatusMember[]): string[] 
   return addrs;
 };
 
-const addrToRemoveLoop = (members: ReplSetStatusMember[]) => {
-  return members.filter(shouldRemoveMember).map((m) => m.name);
+// A forced reconfig is the one write we make with no concurrency check: force skips mongod's config
+// version and term check, so two sidecars that both decide to do primary work don't get an error out
+// of it, they get a lost update - the second config replaces the first and silently drops whatever it
+// had added. Every sidecar runs the same election over its own view of the pod list, and those views
+// disagree exactly while pods are appearing and going away, which is also when no primary exists.
+//
+// mongod offers nothing to compare-and-swap against on a forced write, so the fence is time. Two
+// clocks, and both of them narrow the window rather than close it:
+type ForceGate = {
+  // First loop we saw the condition a forced reconfig would fix. An ordinary election takes about ten
+  // seconds, and a rolling restart is a handful of loops with no primary - neither wants our help.
+  // Waiting the grace out also gives the pod lists time to agree, so the election has one winner.
+  forceNeededSince?: number;
+  // A forced reconfig we have already written. mongod has to elect on that config before the next
+  // observation means anything, and a force built off a config that hasn't landed yet is how one
+  // rename per loop becomes a run of forced reconfigs.
+  lastForcedAt?: number;
 };
 
-const shouldRemoveMember = (member: ReplSetStatusMember): boolean => {
-  const unhealthyThreshold = new Date(new Date().getTime() - config.mongo.unhealthySeconds * 1000);
-  return !member.health && !!member.lastHeartbeatRecv && member.lastHeartbeatRecv < unhealthyThreshold;
+const newForceGate = (): ForceGate => ({});
+
+// Spans work loop iterations like the tracker below, and for the same reason takes the gate as an
+// argument everywhere so tests can pass a fresh one.
+const forceReconfigGate = newForceGate();
+
+const clearForceGate = (gate: ForceGate): void => {
+  delete gate.forceNeededSince;
+  delete gate.lastForcedAt;
 };
 
-export { init, workloop };
+const forceReconfigAllowed = (gate: ForceGate, now: number): boolean => {
+  const graceMs = config.mongo.forceReconfigGraceSeconds * 1000;
+
+  gate.forceNeededSince ??= now;
+
+  const neededForSeconds = Math.round((now - gate.forceNeededSince) / 1000);
+  if (now - gate.forceNeededSince < graceMs) {
+    log.info("Withholding forced reconfig, giving the set time to elect a primary of its own", {
+      neededForSeconds,
+      waitingForSeconds: config.mongo.forceReconfigGraceSeconds,
+    });
+    return false;
+  }
+
+  if (gate.lastForcedAt !== undefined && now - gate.lastForcedAt < graceMs) {
+    log.info("Withholding forced reconfig, one was written too recently to have taken effect", {
+      writtenSecondsAgo: Math.round((now - gate.lastForcedAt) / 1000),
+    });
+    return false;
+  }
+
+  return true;
+};
+
+// Recorded before the reconfig rather than after: a write that throws may still have landed, and
+// either way the answer to a failed force is not to force again on the next loop.
+const markForced = (gate: ForceGate, now: number): void => {
+  gate.lastForcedAt = now;
+};
+
+// When mongod has never had a heartbeat back from a member it reports lastHeartbeatRecv as the
+// epoch, which is arbitrarily old - so a member that is merely still starting up looks long dead and
+// gets removed on the next loop, whatever unhealthySeconds says. For those we time the grace period
+// from when we first saw the member unhealthy instead, keyed by member name.
+type UnhealthyTracker = Map<string, number>;
+
+const newUnhealthyTracker = (): UnhealthyTracker => new Map();
+
+// The grace period spans workloop iterations, so the tracker has to outlive one. Every function that
+// reads or writes it takes it as an argument, so tests can pass a fresh one instead of clearing this.
+const unhealthyTracker = newUnhealthyTracker();
+
+const addrToRemoveLoop = (members: ReplSetStatusMember[], tracker: UnhealthyTracker): string[] => {
+  const now = new Date().getTime();
+
+  const memberNames = new Set(members.map((m) => m.name));
+  for (const name of tracker.keys()) {
+    if (!memberNames.has(name)) {
+      tracker.delete(name);
+    }
+  }
+
+  return members.filter((m) => shouldRemoveMember(m, now, tracker)).map((m) => m.name);
+};
+
+const shouldRemoveMember = (member: ReplSetStatusMember, now: number, tracker: UnhealthyTracker): boolean => {
+  if (member.health) {
+    tracker.delete(member.name);
+    return false;
+  }
+
+  const heartbeatRecv = member.lastHeartbeatRecv?.getTime() ?? 0;
+
+  let unhealthySince: number;
+  let graceSeconds: number;
+  if (heartbeatRecv > 0) {
+    // The member was reachable once, so it really has gone away - unhealthySeconds is the answer
+    unhealthySince = heartbeatRecv;
+    graceSeconds = config.mongo.unhealthySeconds;
+    tracker.delete(member.name);
+  } else {
+    // Never reachable, which is also what a mongod still loading a large dataset looks like. Its pod
+    // is Running, so removing it only gets it re-added on the next loop, and since the tracker entry
+    // is pruned when it leaves the set the grace period restarts each time - churn that never
+    // converges. Give it a grace long enough to cover startup rather than unhealthySeconds.
+    unhealthySince = tracker.get(member.name) ?? now;
+    graceSeconds = Math.max(config.mongo.startupGraceSeconds, config.mongo.unhealthySeconds);
+    tracker.set(member.name, unhealthySince);
+  }
+
+  const remove = now - unhealthySince > graceSeconds * 1000;
+
+  if (remove) {
+    // mongod's own account of why it can't reach the member, which is usually the whole story
+    log.info(`Removing unhealthy member ${member.name}`, {
+      lastHeartbeatMessage: member.lastHeartbeatMessage,
+      lastHeartbeatRecv: member.lastHeartbeatRecv,
+      state: member.stateStr,
+      unhealthyForSeconds: Math.round((now - unhealthySince) / 1000),
+    });
+  }
+
+  return remove;
+};
+
+export {
+  addrToAddLoop,
+  addrToRemoveLoop,
+  clearForceGate,
+  forceReconfigGate,
+  init,
+  inReplicaSet,
+  isSameMemberAsPod,
+  memberToRename,
+  newForceGate,
+  newUnhealthyTracker,
+  primaryWork,
+  workloop,
+};
+
+export type { ForceGate, UnhealthyTracker };

--- a/tests/integration/lifecycle.integration.test.ts
+++ b/tests/integration/lifecycle.integration.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  closePeerClients,
+  configOf,
+  killMongod,
+  pod,
+  podFqdn,
+  podIp,
+  reconfigDirectly,
+  statusOf,
+  until,
+  waitForMongod,
+} from "./support.js";
+
+// The only thing faked here: there is no Kubernetes API in the harness, so the pod list is fed in.
+// Everything else - the connections, the reconfigs, the elections, the heartbeats - is real.
+//
+// Pods stay Running for the whole suite, including while mongo-2's mongod is down. That is the case
+// the sidecar exists for: the Kubernetes API says the pod is fine, only mongod is gone.
+vi.mock("../../src/k8s.js", () => ({ getMongoPods: vi.fn() }));
+
+const { getMongoPods } = await import("../../src/k8s.js");
+const { closeAllDbs } = await import("../../src/mongo.js");
+const { init, workloop } = await import("../../src/worker.js");
+
+const PODS = [pod(0), pod(1), pod(2)];
+
+// One workloop per poll: the sidecar deliberately makes at most one reconfig per iteration, so every
+// convergence here takes several of them
+const driveUntil = async (
+  condition: () => boolean | Promise<boolean>,
+  description: (() => Promise<string> | string) | string,
+  timeoutMs: number = 120_000,
+): Promise<void> => {
+  await until(
+    async () => {
+      await workloop();
+      return await condition();
+    },
+    description,
+    { intervalMs: 500, timeoutMs: timeoutMs },
+  );
+};
+
+const memberHosts = async (): Promise<string[]> => (await configOf(0)).members.map((m) => m.host);
+
+// What the primary itself thinks of every member, for timeout messages: which member went unhealthy,
+// when its last heartbeat landed, and whether anyone is primary at all
+const memberView = async (): Promise<string> => {
+  try {
+    const members = (await statusOf(0)).members ?? [];
+    return JSON.stringify(
+      members.map((m) => ({
+        health: m.health,
+        lastHeartbeatRecv: m.lastHeartbeatRecv,
+        name: m.name,
+        self: m.self,
+        state: m.stateStr,
+      })),
+    );
+  } catch (err) {
+    return `unavailable: ${err instanceof Error ? err.message : "unknown error"}`;
+  }
+};
+
+const reconfigMemberHostTo = async (from: string, to: string): Promise<void> => {
+  await reconfigDirectly(0, (rsConfig) => {
+    const member = rsConfig.members.find((m) => m.host === from);
+    if (!member) {
+      throw new Error(`Member ${from} not found in config: ${rsConfig.members.map((m) => m.host).join(", ")}`);
+    }
+    member.host = to;
+  });
+};
+
+beforeAll(async () => {
+  vi.mocked(getMongoPods).mockResolvedValue(PODS);
+
+  await Promise.all([waitForMongod(0), waitForMongod(1), waitForMongod(2)]);
+
+  init();
+});
+
+afterAll(async () => {
+  await closeAllDbs();
+  await closePeerClients();
+});
+
+describe("replica set lifecycle", () => {
+  it("initiates the set on the elected pod and adds every pod under its FQDN", async () => {
+    await driveUntil(async () => {
+      const hosts = await memberHosts();
+      return hosts.length === 3 && hosts.every((h) => h.endsWith(".db.test-ns.svc.cluster.local:27017"));
+    }, "the replica set to contain all three pods by FQDN");
+
+    expect(await memberHosts()).toEqual(expect.arrayContaining([podFqdn(0), podFqdn(1), podFqdn(2)]));
+
+    // A set the sidecar built has to be a working one, not just a config document
+    const status = await statusOf(0);
+    expect(status.members?.filter((m) => m.stateStr === "PRIMARY")).toHaveLength(1);
+    expect(status.members?.every((m) => m.health === 1)).toBe(true);
+  });
+
+  it("renames a member that is in the set under its pod IP back to its FQDN", async () => {
+    // Put the set into the state a pre-normalization sidecar leaves behind. Done directly, because
+    // the sidecar itself would never write this.
+    await reconfigMemberHostTo(podFqdn(1), podIp(1));
+    expect(await memberHosts()).toContain(podIp(1));
+
+    await driveUntil(
+      async () => {
+        const hosts = await memberHosts();
+        return hosts.includes(podFqdn(1)) && !hosts.includes(podIp(1));
+      },
+      `member ${podIp(1)} to be renamed to ${podFqdn(1)}`,
+    );
+
+    // Renaming must not have duplicated the member
+    expect(await memberHosts()).toHaveLength(3);
+  });
+
+  it("removes a member whose mongod stops answering for longer than the grace period", async () => {
+    await killMongod(2);
+
+    // Two separate waits, because they fail for different reasons: the first is mongod noticing the
+    // heartbeats stopped, the second is the sidecar acting on it
+    await until(
+      async () => (await statusOf(0)).members?.some((m) => m.name === podFqdn(2) && !m.health) === true,
+      async () => `the set to see ${podFqdn(2)} as unhealthy, members: ${await memberView()}`,
+      { timeoutMs: 60_000 },
+    );
+
+    await driveUntil(
+      async () => {
+        const hosts = await memberHosts();
+        return hosts.length === 2 && !hosts.includes(podFqdn(2));
+      },
+      async () => `member ${podFqdn(2)} to be reaped, members: ${await memberView()}`,
+      60_000,
+    );
+  });
+
+  it("adds the pod back once its mongod returns", async () => {
+    await waitForMongod(2);
+
+    await driveUntil(
+      async () => {
+        const hosts = await memberHosts();
+        return hosts.length === 3 && hosts.includes(podFqdn(2));
+      },
+      `member ${podFqdn(2)} to be re-added`,
+    );
+
+    await until(async () => {
+      const status = await statusOf(0);
+      return status.members?.length === 3 && status.members.every((m) => m.health === 1);
+    }, "the re-added member to become healthy");
+  });
+});

--- a/tests/integration/support.ts
+++ b/tests/integration/support.ts
@@ -1,0 +1,169 @@
+import { writeFile } from "fs/promises";
+import { MongoClient } from "mongodb";
+
+import { sleep } from "../../src/utils.js";
+
+import type { ReplSetConfig, ReplSetStatus } from "../../src/types.js";
+import type { V1Pod } from "@kubernetes/client-node";
+
+// Has to agree with docker-compose.itest.yml: the sidecar under test runs in mongo-0's network
+// namespace, so POD_IPS[0] is what getLocalIp() returns and therefore which pod wins the election
+const POD_IPS = ["10.123.45.10", "10.123.45.11", "10.123.45.12"] as const;
+const PORT = 27017;
+
+const podName = (index: number): string => `db-${index}`;
+
+const podIp = (index: number): string => `${POD_IPS[index]}:${PORT}`;
+
+// The host the sidecar is expected to converge on, built the same way utils.getPodFqdn builds it
+const podFqdn = (index: number): string => `${podName(index)}.db.test-ns.svc.cluster.local:${PORT}`;
+
+const pod = (index: number, phase: string = "Running"): V1Pod =>
+  ({
+    metadata: { name: podName(index) },
+    spec: {},
+    status: { phase: phase, podIP: POD_IPS[index] },
+  }) as V1Pod;
+
+// Peer connections opened by the tests themselves, kept apart from the sidecar's own client cache so
+// closing one does not disturb the other
+const peerClients = new Map<number, MongoClient>();
+
+const peerClient = (index: number): MongoClient => {
+  let client = peerClients.get(index);
+  if (!client) {
+    client = new MongoClient(`mongodb://${POD_IPS[index]}:${PORT}`, {
+      connectTimeoutMS: 3000,
+      directConnection: true,
+      serverSelectionTimeoutMS: 3000,
+    });
+    peerClients.set(index, client);
+  }
+
+  return client;
+};
+
+const closePeerClients = async (): Promise<void> => {
+  const clients = [...peerClients.values()];
+  peerClients.clear();
+  await Promise.all(clients.map(async (c) => await c.close().catch(() => undefined)));
+};
+
+// A closed client cannot be reconnected, so a mongod that was shut down needs a fresh one
+const dropPeerClient = async (index: number): Promise<void> => {
+  const client = peerClients.get(index);
+  peerClients.delete(index);
+  await client?.close().catch(() => undefined);
+};
+
+const ping = async (index: number): Promise<boolean> => {
+  try {
+    const client = peerClient(index);
+    await client.db().admin().command({ ping: 1 });
+    return true;
+  } catch {
+    await dropPeerClient(index);
+    return false;
+  }
+};
+
+const waitForMongod = async (index: number): Promise<void> => {
+  await until(async () => await ping(index), `mongod ${podName(index)} to accept connections`);
+};
+
+// Rewrite the replica set config directly, bypassing the sidecar. Used to put the set into a state
+// the sidecar is then expected to correct - the tests can't wait for a real cluster to drift there.
+const reconfigDirectly = async (index: number, mutate: (rsConfig: ReplSetConfig) => void): Promise<void> => {
+  const db = peerClient(index).db();
+  const rsConfig = (await db.admin().command({ replSetGetConfig: 1 })).config as ReplSetConfig;
+
+  mutate(rsConfig);
+  rsConfig.version++;
+
+  // eslint-disable-next-line perfectionist/sort-objects
+  await db.admin().command({ replSetReconfig: rsConfig, force: false });
+};
+
+const statusOf = async (index: number): Promise<ReplSetStatus> => {
+  const db = peerClient(index).db();
+  return (await db.admin().command({ replSetGetStatus: 1 })) as ReplSetStatus;
+};
+
+const configOf = async (index: number): Promise<ReplSetConfig> => {
+  const db = peerClient(index).db();
+  return (await db.admin().command({ replSetGetConfig: 1 })).config as ReplSetConfig;
+};
+
+// Only db-2's container runs mongod under the killswitch wrapper - see docker-compose.itest.yml
+const KILLABLE_INDEX = 2;
+const KILLSWITCH_FILE = "/killswitch/kill";
+
+// Take a mongod down for real, so its peers see heartbeats stop rather than a clean state change.
+// A remote shutdown command is not an option: mongod without auth only accepts it from localhost,
+// and the tests are only local to db-0. So the wrapper around db-2's mongod kills it on our behalf,
+// then holds it down long enough to be reaped before restarting it.
+const killMongod = async (index: number): Promise<void> => {
+  if (index !== KILLABLE_INDEX) {
+    throw new Error(`Only db-${KILLABLE_INDEX} runs under the killswitch wrapper, asked for db-${index}`);
+  }
+
+  await writeFile(KILLSWITCH_FILE, "");
+  await dropPeerClient(index);
+
+  await until(async () => !(await ping(index)), `mongod db-${index} to stop answering`, { timeoutMs: 30_000 });
+};
+
+type UntilOptions = {
+  intervalMs?: number;
+  timeoutMs?: number;
+};
+
+// Poll a condition to a deadline. Anything the condition throws counts as "not yet" - a real cluster
+// mid-reconfig or mid-election refuses commands, and that is the normal case here, not a failure.
+// The description can be a function, so a timeout message can carry the cluster state as it is at the
+// point of failure rather than as it was when the wait started.
+const until = async (
+  condition: () => boolean | Promise<boolean>,
+  description: (() => Promise<string> | string) | string,
+  { intervalMs = 500, timeoutMs = 120_000 }: UntilOptions = {},
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: string | undefined;
+
+  for (;;) {
+    try {
+      if (await condition()) {
+        return;
+      }
+      lastError = undefined;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : "unknown error";
+    }
+
+    if (Date.now() >= deadline) {
+      const because = lastError ? `, last error: ${lastError}` : "";
+      const what = typeof description === "function" ? await description() : description;
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for ${what}${because}`);
+    }
+
+    await sleep(intervalMs);
+  }
+};
+
+export {
+  closePeerClients,
+  configOf,
+  killMongod,
+  peerClient,
+  ping,
+  pod,
+  POD_IPS,
+  podFqdn,
+  podIp,
+  podName,
+  PORT,
+  reconfigDirectly,
+  statusOf,
+  until,
+  waitForMongod,
+};

--- a/tests/mongo.client.test.ts
+++ b/tests/mongo.client.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Records every connection the module opens, keyed by the URI it was built from, so the tests can
+// assert which host a command actually reached rather than which host was asked for
+const constructed: { options: Record<string, unknown>; uri: string }[] = [];
+const connects: string[] = [];
+const closes: string[] = [];
+const commands: { command: unknown; uri: string }[] = [];
+let commandImpl: (uri: string) => unknown = () => ({ config: {} });
+let connectImpl: (uri: string) => void = () => undefined;
+
+vi.mock("mongodb", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("mongodb")>();
+
+  class FakeMongoClient {
+    constructor(
+      readonly uri: string,
+      readonly options: Record<string, unknown>,
+    ) {
+      constructed.push({ options: options, uri: uri });
+    }
+
+    close(): Promise<void> {
+      closes.push(this.uri);
+      return Promise.resolve();
+    }
+
+    connect(): Promise<void> {
+      connects.push(this.uri);
+      connectImpl(this.uri);
+      return Promise.resolve();
+    }
+
+    db(): unknown {
+      return {
+        admin: () => ({
+          command: (command: unknown) => {
+            commands.push({ command: command, uri: this.uri });
+            return commandImpl(this.uri);
+          },
+        }),
+      };
+    }
+  }
+
+  return { ...actual, MongoClient: FakeMongoClient };
+});
+
+const { MongoServerError } = await import("mongodb");
+
+// The client cache is module level, so every test needs a fresh copy of the module
+const loadMongo = async (): Promise<typeof import("../src/mongo.js")> => {
+  vi.resetModules();
+  return await import("../src/mongo.js");
+};
+
+const hostOf = (uri: string): string => uri.replace("mongodb://", "").split(":")[0]!;
+
+beforeEach(() => {
+  constructed.length = 0;
+  connects.length = 0;
+  closes.length = 0;
+  commands.length = 0;
+  commandImpl = () => ({ config: {} });
+  connectImpl = () => undefined;
+});
+
+describe("getDb", () => {
+  it("opens one connection per host rather than reusing the first one", async () => {
+    const { getDb } = await loadMongo();
+
+    await getDb();
+    await getDb("10.0.0.2");
+    await getDb("10.0.0.3");
+
+    expect(connects.map(hostOf)).toEqual(["127.0.0.1", "10.0.0.2", "10.0.0.3"]);
+  });
+
+  it("reuses the cached connection for a host it has already connected to", async () => {
+    const { getDb } = await loadMongo();
+
+    await getDb("10.0.0.2");
+    await getDb("10.0.0.2");
+
+    expect(connects).toHaveLength(1);
+  });
+
+  it("caches nothing when the connection fails, so the next loop retries", async () => {
+    const { getDb } = await loadMongo();
+    connectImpl = () => {
+      throw new Error("connection refused");
+    };
+
+    await expect(getDb("10.0.0.2")).rejects.toThrow("connection refused");
+
+    connectImpl = () => undefined;
+    await getDb("10.0.0.2");
+
+    expect(connects.map(hostOf)).toEqual(["10.0.0.2", "10.0.0.2"]);
+  });
+});
+
+describe("pruneDbCache", () => {
+  it("closes cached connections to hosts that are no longer running", async () => {
+    const { getDb, pruneDbCache } = await loadMongo();
+
+    await getDb("10.0.0.2");
+    await getDb("10.0.0.3");
+
+    await pruneDbCache(["10.0.0.2"]);
+
+    expect(closes.map(hostOf)).toEqual(["10.0.0.3"]);
+  });
+
+  it("keeps the local connection, which is no pod's address", async () => {
+    const { getDb, pruneDbCache } = await loadMongo();
+
+    await getDb();
+    await pruneDbCache(["10.0.0.2"]);
+
+    expect(closes).toEqual([]);
+  });
+
+  it("reconnects to a pruned host if it comes back, rather than serving a closed client", async () => {
+    const { getDb, pruneDbCache } = await loadMongo();
+
+    await getDb("10.0.0.2");
+    await pruneDbCache([]);
+    await getDb("10.0.0.2");
+
+    expect(connects.map(hostOf)).toEqual(["10.0.0.2", "10.0.0.2"]);
+  });
+
+  it("leaves a cache that is entirely live alone", async () => {
+    const { getDb, pruneDbCache } = await loadMongo();
+
+    await getDb("10.0.0.2");
+    await pruneDbCache(["10.0.0.2"]);
+
+    expect(closes).toEqual([]);
+  });
+});
+
+describe("isInReplSet", () => {
+  it("probes the host it was given, not whichever host connected first", async () => {
+    const { getDb, isInReplSet } = await loadMongo();
+
+    // The work loop always opens the local connection before probing any peer
+    await getDb();
+    await isInReplSet("10.0.0.2");
+
+    expect(commands.map((c) => hostOf(c.uri))).toEqual(["10.0.0.2"]);
+  });
+
+  it("reports a peer that is already in a replica set", async () => {
+    const { isInReplSet } = await loadMongo();
+
+    await expect(isInReplSet("10.0.0.2")).resolves.toBe(true);
+  });
+
+  it("reports false when the peer answers that it is not yet initialised", async () => {
+    const { isInReplSet } = await loadMongo();
+    commandImpl = () => {
+      throw new MongoServerError({ code: 94, message: "no replset config has been received" });
+    };
+
+    await expect(isInReplSet("10.0.0.2")).resolves.toBe(false);
+  });
+
+  it("keeps the connection to a peer that answered, as that is the normal bootstrap answer", async () => {
+    const { isInReplSet } = await loadMongo();
+    commandImpl = () => {
+      throw new MongoServerError({ code: 94, message: "no replset config has been received" });
+    };
+
+    await isInReplSet("10.0.0.2");
+    await isInReplSet("10.0.0.2");
+
+    expect(connects).toHaveLength(1);
+    expect(closes).toHaveLength(0);
+  });
+
+  it("reports true when the peer answers with an error other than not-yet-initialised", async () => {
+    const { isInReplSet } = await loadMongo();
+    commandImpl = () => {
+      throw new MongoServerError({ code: 11_000, message: "some other server error" });
+    };
+
+    // Membership is unknown, and a unanimous "no" is what elects a pod to run replSetInitiate -
+    // guessing "not in a set" here would initiate a second replica set over a live one
+    await expect(isInReplSet("10.0.0.2")).resolves.toBe(true);
+  });
+
+  // An auth failure is the one in-set answer that never changes by itself, and it blocks bootstrap of
+  // a set that doesn't exist yet - so the log line has to point at the credentials rather than read as
+  // a problem with the peer
+  it.each([
+    [13, "Unauthorized"],
+    [18, "Authentication failed"],
+  ])("blames our own credentials when a probe cannot authenticate (code %i)", async (code, message) => {
+    const { isInReplSet } = await loadMongo();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    commandImpl = () => {
+      throw new MongoServerError({ code: code, message: message });
+    };
+
+    await expect(isInReplSet("10.0.0.2")).resolves.toBe(true);
+
+    const logged = String(consoleError.mock.calls[0]?.[0]);
+    expect(logged).toContain("MONGODB_USERNAME");
+    expect(logged).toContain("could not authenticate");
+    consoleError.mockRestore();
+  });
+
+  it("does not throw when a peer is unreachable, so one bad pod cannot kill the work loop", async () => {
+    const { isInReplSet } = await loadMongo();
+    connectImpl = () => {
+      throw new Error("connection timed out");
+    };
+
+    await expect(isInReplSet("10.0.0.2")).resolves.toBe(false);
+  });
+
+  it("drops the client after a connection level failure, since pod IPs get recycled", async () => {
+    const { isInReplSet } = await loadMongo();
+    commandImpl = () => {
+      throw new Error("socket closed");
+    };
+
+    await isInReplSet("10.0.0.2");
+    await isInReplSet("10.0.0.2");
+
+    // Both probes fail, and each drops its own client - so the second probe had to reconnect
+    expect(closes.map(hostOf)).toEqual(["10.0.0.2", "10.0.0.2"]);
+    expect(connects.map(hostOf)).toEqual(["10.0.0.2", "10.0.0.2"]);
+  });
+
+  it("bounds how long a probe can hold the work loop", async () => {
+    const { getDb, isInReplSet } = await loadMongo();
+
+    await getDb();
+    await isInReplSet("10.0.0.2");
+
+    const local = constructed.find((c) => hostOf(c.uri) === "127.0.0.1")!;
+    const peer = constructed.find((c) => hostOf(c.uri) === "10.0.0.2")!;
+
+    expect(peer.options.serverSelectionTimeoutMS).toBe(3000);
+    expect(peer.options.connectTimeoutMS).toBe(3000);
+    // The local connection has to survive reconfigs, so it keeps the driver defaults
+    expect(local.options.serverSelectionTimeoutMS).toBeUndefined();
+  });
+});

--- a/tests/mongo.test.ts
+++ b/tests/mongo.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renameReplSetMember } from "../src/mongo.js";
+import { ReplSetConfig } from "../src/types.js";
+
+import type { Db } from "mongodb";
+
+const PORT = 27017;
+
+const rsConfig = (hosts: string[], version: number = 3): ReplSetConfig => ({
+  _id: "rs0",
+  configsvr: false,
+  members: hosts.map((host, i) => ({ _id: i, host })),
+  version,
+});
+
+// replSetGetConfig hands back a fresh copy each time, the way a real round trip would: the
+// production code mutates the config it is given, so a shared object would let the test's own
+// fixture be edited out from under its assertions.
+const fakeDb = (config: ReplSetConfig) => {
+  const command = vi.fn((cmd: Record<string, unknown>) => {
+    if ("replSetGetConfig" in cmd) {
+      return Promise.resolve({ config: structuredClone(config) });
+    }
+    return Promise.resolve({ ok: 1 });
+  });
+
+  return { command, db: { admin: () => ({ command }) } as unknown as Db };
+};
+
+// The second command is the reconfig - the first is always the replSetGetConfig read
+const reconfigArg = (command: ReturnType<typeof fakeDb>["command"]) => command.mock.calls[1]?.[0];
+
+describe("renameReplSetMember", () => {
+  const ip = `10.0.0.2:${PORT}`;
+  const fqdn = `db-1.db.test-ns.svc.cluster.local:${PORT}`;
+  const otherFqdn = `db-0.db.test-ns.svc.cluster.local:${PORT}`;
+
+  it("moves only the named member onto the new host", async () => {
+    const { command, db } = fakeDb(rsConfig([otherFqdn, ip, `10.0.0.3:${PORT}`]));
+
+    await renameReplSetMember(db, ip, fqdn);
+
+    expect(reconfigArg(command)).toMatchObject({
+      replSetReconfig: {
+        members: [
+          { _id: 0, host: otherFqdn },
+          { _id: 1, host: fqdn },
+          { _id: 2, host: `10.0.0.3:${PORT}` },
+        ],
+      },
+    });
+  });
+
+  it("keeps the member's _id, so mongod sees a moved member rather than a new one", async () => {
+    const { command, db } = fakeDb(rsConfig([otherFqdn, ip]));
+
+    await renameReplSetMember(db, ip, fqdn);
+
+    const members = (reconfigArg(command) as { replSetReconfig: ReplSetConfig }).replSetReconfig.members;
+    expect(members).toHaveLength(2);
+    expect(members.find((m) => m.host === fqdn)?._id).toBe(1);
+  });
+
+  it("increments the config version by exactly one", async () => {
+    const { command, db } = fakeDb(rsConfig([otherFqdn, ip], 7));
+
+    await renameReplSetMember(db, ip, fqdn);
+
+    expect(reconfigArg(command)).toMatchObject({ replSetReconfig: { version: 8 } });
+  });
+
+  it("passes force through to the reconfig", async () => {
+    const { command, db } = fakeDb(rsConfig([otherFqdn, ip]));
+
+    await renameReplSetMember(db, ip, fqdn, true);
+
+    expect(reconfigArg(command)).toMatchObject({ force: true });
+  });
+
+  it("defaults to an unforced reconfig", async () => {
+    const { command, db } = fakeDb(rsConfig([otherFqdn, ip]));
+
+    await renameReplSetMember(db, ip, fqdn);
+
+    expect(reconfigArg(command)).toMatchObject({ force: false });
+  });
+
+  it("reconfigs nothing when the member has already left the set", async () => {
+    // The rename target came from a replSetGetStatus taken before this read - the member can be gone
+    // by now, and reconfiguring on that stale view would resurrect it
+    const { command, db } = fakeDb(rsConfig([otherFqdn]));
+
+    await renameReplSetMember(db, ip, fqdn);
+
+    expect(command).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconfigs nothing when another member already holds the target host", async () => {
+    // Two members on one host is a config mongod rejects, and writing it would take the set down.
+    // The duplicate is the remove loop's job, not this one's.
+    const { command, db } = fakeDb(rsConfig([otherFqdn, ip, fqdn]));
+
+    await renameReplSetMember(db, ip, fqdn);
+
+    expect(command).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconfigs nothing when asked to rename a member onto its own host", async () => {
+    const { command, db } = fakeDb(rsConfig([otherFqdn, fqdn]));
+
+    await renameReplSetMember(db, fqdn, fqdn);
+
+    expect(command).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/worker.normalize-off.test.ts
+++ b/tests/worker.normalize-off.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReplSetStatusMember } from "../src/types.js";
+
+import type { V1Pod } from "@kubernetes/client-node";
+import type { Db } from "mongodb";
+
+const NAMESPACE = "test-ns";
+const SERVICE = "db";
+const PORT = 27017;
+const UNHEALTHY_MS = 15 * 1000;
+
+// config.js reads the environment once at import time, so the kill switch can't be flipped per test
+// through the environment. Replacing the module is the only way to exercise the off position - and
+// utils.js reads the same module, so the FQDNs it builds stay consistent with the values here.
+vi.mock("../src/config.js", () => ({
+  config: {
+    kube: {
+      clusterDomain: "cluster.local",
+      clusterSkipTLSVerify: false,
+      labelSelector: "app=solidatus-db",
+      mongoServiceName: SERVICE,
+      namespace: NAMESPACE,
+      normalizeMemberHosts: false,
+    },
+    mongo: {
+      isConfigSvr: false,
+      loopSleepSeconds: 5,
+      port: PORT,
+      startupGraceSeconds: 300,
+      unhealthySeconds: UNHEALTHY_MS / 1000,
+    },
+  },
+}));
+
+vi.mock("../src/k8s.js", () => ({ getMongoPods: vi.fn() }));
+vi.mock("../src/mongo.js", () => ({
+  addNewReplSetMembers: vi.fn(),
+  getDb: vi.fn(),
+  initReplSet: vi.fn(),
+  isInReplSet: vi.fn(),
+  pruneDbCache: vi.fn(),
+  renameReplSetMember: vi.fn(),
+  replSetGetStatus: vi.fn(),
+}));
+
+const LOCAL_IP = "10.0.0.1";
+vi.mock("../src/utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/utils.js")>()),
+  getLocalIp: () => LOCAL_IP,
+}));
+
+const { addNewReplSetMembers, renameReplSetMember } = await import("../src/mongo.js");
+const { init, newUnhealthyTracker, primaryWork } = await import("../src/worker.js");
+
+type UnhealthyTracker = ReturnType<typeof newUnhealthyTracker>;
+
+const fqdn = (hostname: string): string => `${hostname}.${SERVICE}.${NAMESPACE}.svc.cluster.local:${PORT}`;
+
+const pod = (name: string, podIP: string): V1Pod =>
+  ({ metadata: { name }, spec: {}, status: { phase: "Running", podIP } }) as V1Pod;
+
+const member = (name: string, overrides: Partial<ReplSetStatusMember> = {}): ReplSetStatusMember => ({
+  _id: 0,
+  health: 1,
+  name,
+  self: false,
+  state: 2,
+  stateStr: "SECONDARY",
+  ...overrides,
+});
+
+init();
+
+describe("primaryWork with KUBE_NORMALIZE_MEMBER_HOSTS off", () => {
+  const db = {} as Db;
+  const self = pod("db-0", "10.0.0.1");
+  const other = pod("db-1", "10.0.0.2");
+  const selfMember = member(fqdn("db-0"), { self: true });
+
+  let tracker: UnhealthyTracker;
+
+  beforeEach(() => {
+    tracker = newUnhealthyTracker();
+    vi.mocked(addNewReplSetMembers).mockClear();
+    vi.mocked(renameReplSetMember).mockClear();
+  });
+
+  it("leaves a member addressed by IP alone", async () => {
+    await primaryWork(db, [self, other], [selfMember, member(`10.0.0.2:${PORT}`)], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("leaves a member addressed by short service name alone", async () => {
+    await primaryWork(db, [self, other], [selfMember, member(`db-1.db:${PORT}`)], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("leaves our own member alone even when its host name names no pod", async () => {
+    await primaryWork(db, [self], [member(`db:${PORT}`, { self: true })], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("adds a new pod in the same cycle as a misnamed member, which normalization would have deferred", async () => {
+    const third = pod("db-2", "10.0.0.3");
+
+    await primaryWork(db, [self, other, third], [selfMember, member(`10.0.0.2:${PORT}`)], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).toHaveBeenCalledWith(db, [fqdn("db-2")], [], false);
+  });
+
+  it("still reaps a dead member", async () => {
+    const dead = member(`10.0.0.2:${PORT}`, {
+      health: 0,
+      lastHeartbeatRecv: new Date(Date.now() - UNHEALTHY_MS - 1000),
+    });
+
+    await primaryWork(db, [self, other], [selfMember, dead], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).toHaveBeenCalledWith(db, [], [`10.0.0.2:${PORT}`], false);
+  });
+});

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,0 +1,772 @@
+import { MongoServerError } from "mongodb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReplSetConfig, ReplSetConfigMember, ReplSetStatusMember } from "../src/types.js";
+
+import type { V1Pod } from "@kubernetes/client-node";
+import type { Db } from "mongodb";
+import type { MockInstance } from "vitest";
+
+// k8s.js builds a KubeConfig at import time, which needs a real kubeconfig on disk. mongo.js opens
+// no connection at import, but worker.js only ever calls into it from the paths we aren't testing.
+vi.mock("../src/k8s.js", () => ({ getMongoPods: vi.fn() }));
+vi.mock("../src/mongo.js", () => ({
+  addNewReplSetMembers: vi.fn(),
+  getDb: vi.fn(),
+  initReplSet: vi.fn(),
+  isInReplSet: vi.fn(),
+  pruneDbCache: vi.fn(),
+  renameReplSetMember: vi.fn(),
+  replSetGetConfig: vi.fn(),
+  replSetGetStatus: vi.fn(),
+}));
+
+// Pin the address init() picks up so 'self' resolution is deterministic
+const LOCAL_IP = "10.0.0.1";
+vi.mock("../src/utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/utils.js")>()),
+  getLocalIp: () => LOCAL_IP,
+}));
+
+const { getMongoPods } = await import("../src/k8s.js");
+const {
+  addNewReplSetMembers,
+  getDb,
+  initReplSet,
+  isInReplSet,
+  renameReplSetMember,
+  replSetGetConfig,
+  replSetGetStatus,
+} = await import("../src/mongo.js");
+const {
+  addrToAddLoop,
+  addrToRemoveLoop,
+  clearForceGate,
+  forceReconfigGate,
+  init,
+  inReplicaSet,
+  isSameMemberAsPod,
+  memberToRename,
+  newForceGate,
+  newUnhealthyTracker,
+  primaryWork,
+  workloop,
+} = await import("../src/worker.js");
+
+type ForceGate = ReturnType<typeof newForceGate>;
+type UnhealthyTracker = ReturnType<typeof newUnhealthyTracker>;
+
+// Matches vitest.config.mts, which is what config.js loaded
+const NAMESPACE = "test-ns";
+const SERVICE = "db";
+const PORT = 27017;
+const UNHEALTHY_MS = 15 * 1000;
+const STARTUP_GRACE_MS = 300 * 1000;
+const FORCE_GRACE_MS = 30 * 1000;
+
+const fqdn = (hostname: string, service: string = SERVICE, namespace: string = NAMESPACE): string =>
+  `${hostname}.${service}.${namespace}.svc.cluster.local:${PORT}`;
+
+const pod = (name: string, podIP: string, phase: string = "Running", hostname?: string): V1Pod =>
+  ({
+    metadata: { name },
+    spec: hostname ? { hostname } : {},
+    status: { phase, podIP },
+  }) as V1Pod;
+
+const member = (name: string, overrides: Partial<ReplSetStatusMember> = {}): ReplSetStatusMember => ({
+  _id: 0,
+  health: 1,
+  name,
+  self: false,
+  state: 2,
+  stateStr: "SECONDARY",
+  ...overrides,
+});
+
+init();
+
+describe("isSameMemberAsPod", () => {
+  const db0 = pod("db-0", "10.0.0.1");
+
+  it("matches the pod FQDN", () => {
+    expect(isSameMemberAsPod(fqdn("db-0"), db0)).toBe(true);
+  });
+
+  it("matches the pod IP and port", () => {
+    expect(isSameMemberAsPod(`10.0.0.1:${PORT}`, db0)).toBe(true);
+  });
+
+  it("matches the service-scoped short name, which carries no namespace", () => {
+    expect(isSameMemberAsPod(`db-0.db:${PORT}`, db0)).toBe(true);
+  });
+
+  it("matches a bare pod name", () => {
+    expect(isSameMemberAsPod(`db-0:${PORT}`, db0)).toBe(true);
+  });
+
+  it("prefers spec.hostname over metadata.name", () => {
+    const renamed = pod("db-0", "10.0.0.1", "Running", "mongo-0");
+    expect(isSameMemberAsPod(`mongo-0:${PORT}`, renamed)).toBe(true);
+    expect(isSameMemberAsPod(`db-0:${PORT}`, renamed)).toBe(false);
+  });
+
+  it("rejects a different hostname", () => {
+    expect(isSameMemberAsPod(fqdn("db-1"), db0)).toBe(false);
+  });
+
+  it("rejects the same pod name in another namespace", () => {
+    expect(isSameMemberAsPod(fqdn("db-0", SERVICE, "other-ns"), db0)).toBe(false);
+  });
+
+  it("rejects the same pod name behind another service", () => {
+    expect(isSameMemberAsPod(fqdn("db-0", "other-svc"), db0)).toBe(false);
+  });
+
+  it("rejects a different port", () => {
+    expect(isSameMemberAsPod(`db-0.db.${NAMESPACE}.svc.cluster.local:27018`, db0)).toBe(false);
+  });
+
+  it("rejects a host with no port at all", () => {
+    expect(isSameMemberAsPod("db-0", db0)).toBe(false);
+  });
+
+  it("rejects a pod with no hostname to compare against", () => {
+    const nameless = { spec: {}, status: { phase: "Running" } } as V1Pod;
+    expect(isSameMemberAsPod(`db-0:${PORT}`, nameless)).toBe(false);
+  });
+});
+
+describe("memberToRename", () => {
+  const self = pod("db-0", "10.0.0.1");
+  const other = pod("db-1", "10.0.0.2");
+
+  it("returns nothing when every member already uses its pod FQDN", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(fqdn("db-1"))];
+    expect(memberToRename([self, other], members)).toBeUndefined();
+  });
+
+  it("renames a member addressed by IP", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(`10.0.0.2:${PORT}`)];
+    expect(memberToRename([self, other], members)).toEqual({ from: `10.0.0.2:${PORT}`, to: fqdn("db-1") });
+  });
+
+  it("renames a member addressed by short service name", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(`db-1.db:${PORT}`)];
+    expect(memberToRename([self, other], members)).toEqual({ from: `db-1.db:${PORT}`, to: fqdn("db-1") });
+  });
+
+  it("resolves self by local IP even when the host name is unrecognisable", () => {
+    const members = [member(`db:${PORT}`, { self: true })];
+    expect(memberToRename([self, other], members)).toEqual({ from: `db:${PORT}`, to: fqdn("db-0") });
+  });
+
+  it("skips a rename whose target FQDN is already held by another member", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(`10.0.0.2:${PORT}`), member(fqdn("db-1"))];
+    expect(memberToRename([self, other], members)).toBeUndefined();
+  });
+
+  it("ignores pods that aren't Running", () => {
+    const pending = pod("db-1", "10.0.0.2", "Pending");
+    const members = [member(fqdn("db-0"), { self: true }), member(`10.0.0.2:${PORT}`)];
+    expect(memberToRename([self, pending], members)).toBeUndefined();
+  });
+
+  it("ignores members with no pod behind them", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(fqdn("db-9"))];
+    expect(memberToRename([self], members)).toBeUndefined();
+  });
+
+  it("returns only the first rename, so a reconfig never carries two", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(`10.0.0.2:${PORT}`), member(`db-2.db:${PORT}`)];
+    const third = pod("db-2", "10.0.0.3");
+    expect(memberToRename([self, other, third], members)).toEqual({
+      from: `10.0.0.2:${PORT}`,
+      to: fqdn("db-1"),
+    });
+  });
+});
+
+describe("addrToAddLoop", () => {
+  const self = pod("db-0", "10.0.0.1");
+  const other = pod("db-1", "10.0.0.2");
+
+  it("adds a pod that is not a member", () => {
+    expect(addrToAddLoop([self, other], [member(fqdn("db-0"), { self: true })], true)).toEqual([fqdn("db-1")]);
+  });
+
+  it("adds nothing when every pod is already a member", () => {
+    expect(addrToAddLoop([self, other], [member(fqdn("db-0"), { self: true }), member(fqdn("db-1"))], true)).toEqual(
+      [],
+    );
+  });
+
+  it("recognises members addressed by IP or short name", () => {
+    const members = [member(`10.0.0.1:${PORT}`, { self: true }), member(`db-1.db:${PORT}`)];
+    expect(addrToAddLoop([self, other], members, true)).toEqual([]);
+  });
+
+  it("never re-adds ourselves when the members list is non-empty, whatever host name we're under", () => {
+    // Our own mongod answered replSetGetStatus, so it is a member under some name we can't parse
+    expect(addrToAddLoop([self], [member(`db:${PORT}`, { self: true })], true)).toEqual([]);
+  });
+
+  it("adds ourselves when the members list is empty, which is the forced reinit path", () => {
+    expect(addrToAddLoop([self, other], [], true)).toEqual([fqdn("db-0"), fqdn("db-1")]);
+  });
+
+  it("adds ourselves to a non-empty list our own name is missing from when membership isn't assumed", () => {
+    // The config-doc caller can't take its own membership on trust: a config that doesn't contain us
+    // is one of the things error 93 means, and then we are the member nobody else will add
+    expect(addrToAddLoop([self, other], [{ name: fqdn("db-1") }], false)).toEqual([fqdn("db-0")]);
+  });
+
+  it("still recognises our own name when membership isn't assumed", () => {
+    expect(addrToAddLoop([self], [{ name: fqdn("db-0") }], false)).toEqual([]);
+    expect(addrToAddLoop([self], [{ name: `10.0.0.1:${PORT}` }], false)).toEqual([]);
+  });
+
+  it("skips pods that aren't Running", () => {
+    expect(addrToAddLoop([self, pod("db-1", "10.0.0.2", "Pending")], [], true)).toEqual([fqdn("db-0")]);
+  });
+
+  it("falls back to the pod IP when there is no hostname to build an FQDN from", () => {
+    const nameless = { spec: {}, status: { phase: "Running", podIP: "10.0.0.2" } } as V1Pod;
+    expect(addrToAddLoop([nameless], [], true)).toEqual([`10.0.0.2:${PORT}`]);
+  });
+
+  it("skips a pod with neither hostname nor IP", () => {
+    const empty = { spec: {}, status: { phase: "Running" } } as V1Pod;
+    expect(addrToAddLoop([empty], [], true)).toEqual([]);
+  });
+});
+
+describe("addrToRemoveLoop", () => {
+  let tracker: UnhealthyTracker;
+
+  beforeEach(() => {
+    tracker = newUnhealthyTracker();
+    vi.useRealTimers();
+  });
+
+  it("keeps healthy members", () => {
+    expect(addrToRemoveLoop([member(fqdn("db-0"), { health: 1 })], tracker)).toEqual([]);
+  });
+
+  it("removes an unhealthy member whose last heartbeat is older than the threshold", () => {
+    const stale = member(fqdn("db-0"), {
+      health: 0,
+      lastHeartbeatRecv: new Date(Date.now() - UNHEALTHY_MS - 1000),
+    });
+    expect(addrToRemoveLoop([stale], tracker)).toEqual([fqdn("db-0")]);
+  });
+
+  it("keeps an unhealthy member whose last heartbeat is recent", () => {
+    const recent = member(fqdn("db-0"), { health: 0, lastHeartbeatRecv: new Date(Date.now() - 1000) });
+    expect(addrToRemoveLoop([recent], tracker)).toEqual([]);
+  });
+
+  it("gives a member that has never heartbeat the startup grace from first sighting", () => {
+    vi.useFakeTimers();
+    // The epoch is what mongod reports before the first heartbeat back - arbitrarily old, but the
+    // member may simply still be starting up
+    const starting = member(fqdn("db-0"), { health: 0, lastHeartbeatRecv: new Date(0) });
+
+    expect(addrToRemoveLoop([starting], tracker)).toEqual([]);
+
+    // Well past unhealthySeconds: a mongod loading a large dataset is still Running, so removing it
+    // here only gets it re-added and the grace restarted, forever
+    vi.advanceTimersByTime(UNHEALTHY_MS + 1000);
+    expect(addrToRemoveLoop([starting], tracker)).toEqual([]);
+
+    vi.advanceTimersByTime(STARTUP_GRACE_MS - UNHEALTHY_MS - 1000);
+    expect(addrToRemoveLoop([starting], tracker)).toEqual([]);
+
+    vi.advanceTimersByTime(2000);
+    expect(addrToRemoveLoop([starting], tracker)).toEqual([fqdn("db-0")]);
+  });
+
+  it("treats a missing lastHeartbeatRecv the same as the epoch", () => {
+    vi.useFakeTimers();
+    const starting = member(fqdn("db-0"), { health: 0 });
+
+    expect(addrToRemoveLoop([starting], tracker)).toEqual([]);
+
+    vi.advanceTimersByTime(STARTUP_GRACE_MS + 1000);
+    expect(addrToRemoveLoop([starting], tracker)).toEqual([fqdn("db-0")]);
+  });
+
+  it("restarts the grace period once a member recovers", () => {
+    vi.useFakeTimers();
+    const name = fqdn("db-0");
+
+    addrToRemoveLoop([member(name, { health: 0, lastHeartbeatRecv: new Date(0) })], tracker);
+    vi.advanceTimersByTime(UNHEALTHY_MS - 1000);
+
+    // A healthy sighting clears the entry, so the clock starts again from here
+    addrToRemoveLoop([member(name, { health: 1 })], tracker);
+    expect(tracker.has(name)).toBe(false);
+
+    vi.advanceTimersByTime(2000);
+    expect(addrToRemoveLoop([member(name, { health: 0, lastHeartbeatRecv: new Date(0) })], tracker)).toEqual([]);
+  });
+
+  it("forgets a member that leaves the set, so a re-added one starts fresh", () => {
+    vi.useFakeTimers();
+    const name = fqdn("db-0");
+
+    addrToRemoveLoop([member(name, { health: 0, lastHeartbeatRecv: new Date(0) })], tracker);
+    vi.advanceTimersByTime(UNHEALTHY_MS - 1000);
+
+    // Member gone from the set entirely - its tracking entry must go with it
+    addrToRemoveLoop([], tracker);
+    expect(tracker.has(name)).toBe(false);
+
+    vi.advanceTimersByTime(2000);
+    expect(addrToRemoveLoop([member(name, { health: 0, lastHeartbeatRecv: new Date(0) })], tracker)).toEqual([]);
+  });
+
+  it("does not reap a starting member on the cadence of a remove/re-add cycle", () => {
+    vi.useFakeTimers();
+    const name = fqdn("db-0");
+    const starting = () => member(name, { health: 0, lastHeartbeatRecv: new Date(0) });
+
+    // Whatever a removal does to the tracker, the member must survive several unhealthySeconds
+    // worth of loops - otherwise it is removed and re-added on every cycle and never converges
+    for (let i = 0; i < 5; i++) {
+      expect(addrToRemoveLoop([starting()], tracker)).toEqual([]);
+      vi.advanceTimersByTime(UNHEALTHY_MS);
+    }
+  });
+
+  it("removes several unhealthy members at once", () => {
+    const stale = (name: string) =>
+      member(name, { health: 0, lastHeartbeatRecv: new Date(Date.now() - UNHEALTHY_MS - 1000) });
+    expect(addrToRemoveLoop([stale(fqdn("db-0")), member(fqdn("db-1")), stale(fqdn("db-2"))], tracker)).toEqual([
+      fqdn("db-0"),
+      fqdn("db-2"),
+    ]);
+  });
+
+  it("returns nothing for an empty members list", () => {
+    expect(addrToRemoveLoop([], tracker)).toEqual([]);
+  });
+
+  it("tracks only members that have never heartbeat", () => {
+    const withHeartbeat = member(fqdn("db-0"), { health: 0, lastHeartbeatRecv: new Date(Date.now() - 1000) });
+    const never = member(fqdn("db-1"), { health: 0, lastHeartbeatRecv: new Date(0) });
+
+    addrToRemoveLoop([withHeartbeat, never, member(fqdn("db-2"))], tracker);
+
+    // A real heartbeat time is its own clock, so only db-1 needs an entry
+    expect([...tracker.keys()]).toEqual([fqdn("db-1")]);
+  });
+});
+
+describe("primaryWork", () => {
+  const db = {} as Db;
+  const self = pod("db-0", "10.0.0.1");
+  const other = pod("db-1", "10.0.0.2");
+  const selfMember = member(fqdn("db-0"), { self: true });
+  const dead = (name: string) =>
+    member(name, { health: 0, lastHeartbeatRecv: new Date(Date.now() - UNHEALTHY_MS - 1000) });
+
+  let tracker: UnhealthyTracker;
+
+  beforeEach(() => {
+    tracker = newUnhealthyTracker();
+    vi.mocked(addNewReplSetMembers).mockClear();
+    vi.mocked(renameReplSetMember).mockClear();
+  });
+
+  it("reaps a dead member before renaming anything", async () => {
+    // db-1 is both misnamed and dead. A reconfig needs a majority reachable, so renaming first
+    // would fail forever and the early return would stop us ever reaping it
+    await primaryWork(db, [self, other], [selfMember, dead(`10.0.0.2:${PORT}`)], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).toHaveBeenCalledWith(db, [], [`10.0.0.2:${PORT}`], false);
+  });
+
+  it("renames once nothing needs reaping, and does not touch membership in the same reconfig", async () => {
+    await primaryWork(db, [self, other], [selfMember, member(`10.0.0.2:${PORT}`)], false, tracker);
+
+    expect(renameReplSetMember).toHaveBeenCalledWith(db, `10.0.0.2:${PORT}`, fqdn("db-1"), false);
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("forces the rename reconfig when we're a secondary doing primary work", async () => {
+    // Non-forced reconfig on a secondary is rejected by mongod, which would throw before add/remove
+    await primaryWork(db, [self, other], [selfMember, member(`10.0.0.2:${PORT}`)], true, tracker);
+
+    expect(renameReplSetMember).toHaveBeenCalledWith(db, `10.0.0.2:${PORT}`, fqdn("db-1"), true);
+  });
+
+  it("adds new pods once every member name has converged", async () => {
+    const third = pod("db-2", "10.0.0.3");
+
+    await primaryWork(db, [self, other, third], [selfMember, member(fqdn("db-1"))], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).toHaveBeenCalledWith(db, [fqdn("db-2")], [], false);
+  });
+
+  it("reconfigs nothing when the set already matches the pods", async () => {
+    await primaryWork(db, [self, other], [selfMember, member(fqdn("db-1"))], false, tracker);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+});
+
+describe("inReplicaSet", () => {
+  const db = {} as Db;
+  const self = pod("db-0", "10.0.0.1");
+  const other = pod("db-1", "10.0.0.2");
+  const third = pod("db-2", "10.0.0.3");
+  const primary = (name: string, overrides: Partial<ReplSetStatusMember> = {}) =>
+    member(name, { state: 1, stateStr: "PRIMARY", ...overrides });
+
+  // No tracker argument here: inReplicaSet owns the module-level one, which these cases never write
+  // to - every member they pass is healthy. The force gate is passed in, since these cases do write
+  // to it and a forced reconfig withheld by another test's leftover clock would look like a pass.
+  let gate: ForceGate;
+
+  beforeEach(() => {
+    vi.mocked(addNewReplSetMembers).mockClear();
+    vi.mocked(renameReplSetMember).mockClear();
+    gate = newForceGate();
+    vi.useRealTimers();
+  });
+
+  // Elapsed time is the only fence a forced reconfig has, so anything that has to force walks the
+  // clock forward the way the work loop would
+  const runLoops = async (pods: V1Pod[], members: ReplSetStatusMember[], loops: number) => {
+    for (let i = 0; i < loops; i++) {
+      if (i > 0) {
+        vi.advanceTimersByTime(FORCE_GRACE_MS + 1000);
+      }
+      await inReplicaSet(db, pods, { members, set: "rs0" }, gate);
+    }
+  };
+
+  it("does nothing when removed from the set, where mongod reports no members at all", async () => {
+    // Only a single pod is running, so this one would otherwise win the election and do primary work
+    await inReplicaSet(db, [self], { myState: 10, set: "rs0" });
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  // The removed-set case above passes trivially if nothing ever reconfigs, so pin the cases that
+  // must reconfig alongside it
+  it("does primary work unforced when we are the primary", async () => {
+    const members = [primary(fqdn("db-0"), { self: true }), member(fqdn("db-1"))];
+
+    await inReplicaSet(db, [self, other, third], { members, set: "rs0" }, gate);
+
+    expect(addNewReplSetMembers).toHaveBeenCalledWith(db, [fqdn("db-2")], [], false);
+  });
+
+  it("does nothing when another member is the primary", async () => {
+    const members = [member(fqdn("db-0"), { self: true }), primary(fqdn("db-1"))];
+
+    await inReplicaSet(db, [self, other, third], { members, set: "rs0" }, gate);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("forces primary work once no primary has persisted for the force grace", async () => {
+    vi.useFakeTimers();
+    const members = [member(fqdn("db-0"), { self: true }), member(fqdn("db-1"))];
+
+    // A forced reconfig has no version check behind it, so the first sighting of no primary buys
+    // nothing but the start of a clock - an ordinary election is still in progress at this point
+    await runLoops([self, other, third], members, 1);
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+
+    await runLoops([self, other, third], members, 2);
+    expect(addNewReplSetMembers).toHaveBeenCalledExactlyOnceWith(db, [fqdn("db-2")], [], true);
+  });
+
+  it("does not force again until the last forced reconfig has had time to take effect", async () => {
+    vi.useFakeTimers();
+    const members = [member(fqdn("db-0"), { self: true }), member(fqdn("db-1"))];
+
+    await runLoops([self, other, third], members, 2);
+    expect(addNewReplSetMembers).toHaveBeenCalledTimes(1);
+
+    // mongod has to elect on the config we just wrote before another observation means anything, and
+    // a second force in that window is built off a config that may not have landed
+    vi.advanceTimersByTime(FORCE_GRACE_MS - 1000);
+    await inReplicaSet(db, [self, other, third], { members, set: "rs0" }, gate);
+    expect(addNewReplSetMembers).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(2000);
+    await inReplicaSet(db, [self, other, third], { members, set: "rs0" }, gate);
+    expect(addNewReplSetMembers).toHaveBeenCalledTimes(2);
+  });
+
+  it("restarts the force grace once the set has elected a primary of its own", async () => {
+    vi.useFakeTimers();
+    const noPrimary = [member(fqdn("db-0"), { self: true }), member(fqdn("db-1"))];
+    const withPrimary = [primary(fqdn("db-0"), { self: true }), member(fqdn("db-1"))];
+
+    // Nearly through the grace, then the set sorts itself out - the next spell without a primary is a
+    // new one and has to wait all over again, or a flapping primary adds up to a forced reconfig
+    await inReplicaSet(db, [self, other, third], { members: noPrimary, set: "rs0" }, gate);
+    vi.advanceTimersByTime(FORCE_GRACE_MS - 1000);
+    await inReplicaSet(db, [self, other, third], { members: withPrimary, set: "rs0" }, gate);
+    vi.mocked(addNewReplSetMembers).mockClear();
+
+    vi.advanceTimersByTime(2000);
+    await inReplicaSet(db, [self, other, third], { members: noPrimary, set: "rs0" }, gate);
+
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no primary and another pod wins the election", async () => {
+    vi.useFakeTimers();
+    const lowest = pod("db-9", "10.0.0.0");
+    const members = [member(fqdn("db-0"), { self: true }), member(fqdn("db-1"))];
+
+    await runLoops([self, other, lowest], members, 3);
+
+    expect(renameReplSetMember).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+});
+
+// Error 93 (InvalidReplicaSetConfig) is the one path that can't read the set through
+// replSetGetStatus, so it works off the local config doc instead - a different member shape, a
+// different notion of what this pod's own membership can be assumed to be, and a forced reconfig on a
+// live set if it gets either wrong.
+describe("workloop on an invalid replica set config", () => {
+  const db = {} as Db;
+  const self = pod("db-0", "10.0.0.1");
+  const other = pod("db-1", "10.0.0.2");
+
+  const configMember = (host: string, _id: number = 0): ReplSetConfigMember => ({ _id, host });
+  const rsConfig = (...members: ReplSetConfigMember[]): ReplSetConfig => ({
+    _id: "rs0",
+    configsvr: false,
+    members,
+    version: 1,
+  });
+
+  const invalidConfig = () => {
+    const err = new MongoServerError({ codeName: "InvalidReplicaSetConfig", message: "invalid" });
+    err.code = 93;
+    return err;
+  };
+
+  let consoleError: MockInstance<typeof console.error>;
+
+  beforeEach(() => {
+    vi.mocked(addNewReplSetMembers).mockClear();
+    vi.mocked(replSetGetConfig).mockClear();
+    vi.mocked(getDb).mockResolvedValue(db);
+    vi.mocked(replSetGetStatus).mockRejectedValue(invalidConfig());
+    // workloop swallows everything it throws, so an assertion that some reconfig didn't happen would
+    // pass just as happily on a TypeError. Fail the test on the log line that swallowing writes.
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    // workloop owns the module-level gate, so unlike inReplicaSet these cases can't be handed a fresh
+    // one - and a clock left running by an earlier test would let the first loop force a reconfig
+    vi.useFakeTimers();
+    clearForceGate(forceReconfigGate);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    vi.useRealTimers();
+  });
+
+  // Two loops with the force grace between them: error 93 is fixed by a forced reconfig, and the
+  // first sighting of it only starts that clock
+  const runLoop = async (pods: V1Pod[], config: ReplSetConfig) => {
+    vi.mocked(getMongoPods).mockResolvedValue(pods);
+    vi.mocked(replSetGetConfig).mockResolvedValue(config);
+
+    await workloop();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(FORCE_GRACE_MS + 1000);
+    await workloop();
+
+    expect(consoleError).not.toHaveBeenCalled();
+  };
+
+  it("adds the pods the config is missing, forced, and against the config's own host names", async () => {
+    // Config addresses db-1 by IP: compared against the FQDN we would generate that looks like a
+    // non-member, and adding it duplicates the mongod under a second name
+    await runLoop([self, other], rsConfig(configMember(fqdn("db-0")), configMember(`10.0.0.2:${PORT}`, 1)));
+
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("adds this pod when the config it holds does not contain it", async () => {
+    // The other meaning of error 93. Nobody else is going to add us: the pods in that config can't
+    // see a member that isn't there, and this pod won the election to fix it
+    await runLoop([self, other], rsConfig(configMember(fqdn("db-1"))));
+
+    expect(addNewReplSetMembers).toHaveBeenCalledWith(db, [fqdn("db-0")], [], true);
+  });
+
+  it("adds a pod missing from the config alongside ourselves", async () => {
+    const third = pod("db-2", "10.0.0.3");
+
+    await runLoop([self, other, third], rsConfig(configMember(fqdn("db-1"))));
+
+    expect(addNewReplSetMembers).toHaveBeenCalledWith(db, [fqdn("db-0"), fqdn("db-2")], [], true);
+  });
+
+  it("does not reconfigure when every running pod is already in the config", async () => {
+    // A forced reconfig of an unchanged config doesn't clear error 93, it only bumps the version -
+    // and the work loop would do it again every few seconds forever
+    await runLoop([self, other], rsConfig(configMember(fqdn("db-0")), configMember(fqdn("db-1"), 1)));
+
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+
+  it("does nothing at all when another pod wins the election", async () => {
+    const lowest = pod("db-9", "10.0.0.0");
+
+    await runLoop([self, lowest], rsConfig(configMember(fqdn("db-9"))));
+
+    expect(replSetGetConfig).not.toHaveBeenCalled();
+    expect(addNewReplSetMembers).not.toHaveBeenCalled();
+  });
+});
+
+// The bootstrap path is the one place an address is taken from the pod list rather than from the
+// replica set, so it is the one that can pick the wrong pod if it reads the list in the wrong order.
+describe("workloop on a replica set that does not exist yet", () => {
+  const db = {} as Db;
+  const self = pod("db-0", "10.0.0.1");
+  const higher = pod("db-1", "10.0.0.2");
+
+  const notYetInitialized = () => {
+    const err = new MongoServerError({ codeName: "NotYetInitialized", message: "no replset config" });
+    err.code = 94;
+    return err;
+  };
+
+  beforeEach(() => {
+    vi.mocked(initReplSet).mockClear();
+    vi.mocked(getDb).mockResolvedValue(db);
+    vi.mocked(replSetGetStatus).mockRejectedValue(notYetInitialized());
+    vi.mocked(isInReplSet).mockResolvedValue(false);
+  });
+
+  it("seeds the set with the elected pod's own address, whatever order the pod list arrives in", async () => {
+    // This pod holds the lowest IP and so wins, but the API listed it last
+    vi.mocked(getMongoPods).mockResolvedValue([higher, self]);
+
+    await workloop();
+
+    expect(initReplSet).toHaveBeenCalledWith(db, fqdn("db-0"));
+  });
+
+  it("does not initiate a set when a peer is already in one", async () => {
+    vi.mocked(getMongoPods).mockResolvedValue([self, higher]);
+    vi.mocked(isInReplSet).mockResolvedValue(true);
+
+    await workloop();
+
+    expect(initReplSet).not.toHaveBeenCalled();
+  });
+
+  it("does not initiate a set when another pod wins the election", async () => {
+    vi.mocked(getMongoPods).mockResolvedValue([self, pod("db-9", "10.0.0.0")]);
+
+    await workloop();
+
+    expect(initReplSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("member host convergence", () => {
+  const pods = [pod("db-0", "10.0.0.1"), pod("db-1", "10.0.0.2"), pod("db-2", "10.0.0.3")];
+
+  // Drive memberToRename the way the work loop does - one rename per cycle, applied before the next
+  // call - and assert it runs out of work. Single-cycle tests can't see the two failures that would
+  // actually cost us a cluster: a rename that keeps re-proposing itself, and a pair that swap names
+  // back and forth forever, both of which reconfig the live set on every pass.
+  const converge = (members: ReplSetStatusMember[], maxCycles: number = 20) => {
+    let current = members;
+    const applied: { from: string; to: string }[] = [];
+
+    for (let i = 0; i < maxCycles; i++) {
+      const rename = memberToRename(pods, current);
+      if (!rename) {
+        return { applied, members: current };
+      }
+
+      applied.push(rename);
+      current = current.map((m) => (m.name === rename.from ? { ...m, name: rename.to } : m));
+    }
+
+    throw new Error(`Did not converge in ${maxCycles} cycles: ${JSON.stringify(applied)}`);
+  };
+
+  it("converges a set addressed entirely by pod IP, one rename per member", () => {
+    const members = [
+      member(`10.0.0.1:${PORT}`, { self: true }),
+      member(`10.0.0.2:${PORT}`),
+      member(`10.0.0.3:${PORT}`),
+    ];
+
+    const { applied, members: result } = converge(members);
+
+    expect(applied).toHaveLength(3);
+    expect(result.map((m) => m.name)).toEqual([fqdn("db-0"), fqdn("db-1"), fqdn("db-2")]);
+  });
+
+  it("converges a set of mixed spellings", () => {
+    const members = [
+      member(`db:${PORT}`, { self: true }), // names no pod at all - only 'self' ties it to one
+      member(`db-1.db:${PORT}`),
+      member(fqdn("db-2")),
+    ];
+
+    const { applied, members: result } = converge(members);
+
+    expect(applied).toHaveLength(2);
+    expect(result.map((m) => m.name)).toEqual([fqdn("db-0"), fqdn("db-1"), fqdn("db-2")]);
+  });
+
+  it("proposes nothing further once every member holds its pod FQDN", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(fqdn("db-1")), member(fqdn("db-2"))];
+
+    expect(converge(members).applied).toEqual([]);
+  });
+
+  it("leaves a member no pod backs alone rather than cycling on it", () => {
+    const members = [member(fqdn("db-0"), { self: true }), member(`10.0.0.2:${PORT}`), member(fqdn("db-9"))];
+
+    const { applied, members: result } = converge(members);
+
+    expect(applied).toEqual([{ from: `10.0.0.2:${PORT}`, to: fqdn("db-1") }]);
+    expect(result.map((m) => m.name)).toContain(fqdn("db-9"));
+  });
+
+  it("stops rather than collapsing a duplicate pair onto one host", () => {
+    // db-1 is in the set twice, under its IP and its FQDN. Renaming the IP entry would write a
+    // config with two members on one host, which mongod rejects - the remove loop reaps it instead.
+    const members = [member(fqdn("db-0"), { self: true }), member(`10.0.0.2:${PORT}`), member(fqdn("db-1"))];
+
+    expect(converge(members).applied).toEqual([]);
+  });
+
+  it("never renames a member onto a name another member is about to vacate", () => {
+    // Both entries are misnamed and both would resolve onto FQDNs currently free. If the second
+    // rename targeted the name the first just left, the two would trade places on every cycle.
+    const members = [member(`10.0.0.2:${PORT}`, { _id: 1 }), member(`db-2.db:${PORT}`, { _id: 2 })];
+
+    const { applied } = converge(members);
+
+    const vacated = new Set(applied.map((r) => r.from));
+    expect(applied.filter((r) => vacated.has(r.to))).toEqual([]);
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  /* What actually ships: src only - tests live in ./tests, tooling config in the root */
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*.ts"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   /* Check out https://node.green & https://github.com/tsconfig/bases for some good info */
   /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
-  /* Include all TS files */
-  "include": ["./**/*.ts"],
+  /* Include all TS files, tests & config included, so ESLint can type check them too.
+     The build uses tsconfig.build.json, which drops everything that isn't shipped. */
+  "include": ["./**/*.ts", "./**/*.mts"],
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "dist",
 
     /* Follow https://github.com/tsconfig/bases/blob/main/bases/node24.json */
@@ -29,6 +29,6 @@
     /* AI recommended, seems good */
     "noFallthroughCasesInSwitch": true,
     /* AI recommended, seems good */
-    "noImplicitOverride": true,
+    "noImplicitOverride": true
   }
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,21 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // config.js reads the environment once at import time, so these have to be set before any
+    // module under test is loaded - vitest applies them to the worker process for us
+    env: {
+      KUBE_CLUSTER_DOMAIN: "cluster.local",
+      KUBE_MONGO_SERVICE_NAME: "db",
+      KUBE_NAMESPACE: "test-ns",
+      MONGODB_FORCE_RECONFIG_GRACE_SECONDS: "30",
+      MONGODB_PORT: "27017",
+      MONGODB_UNHEALTHY_SECONDS: "15",
+    },
+    // Integration tests need real mongods; run them only via `npm run test:integration`.
+    exclude: [...configDefaults.exclude, "tests/**/*.integration.test.ts"],
+    include: ["tests/**/*.test.ts"],
+    // Where the junit reporter writes when enabled (via the test-teamcity script).
+    outputFile: { junit: "reports/junit.xml" },
+  },
+});

--- a/vitest.integration.config.mts
+++ b/vitest.integration.config.mts
@@ -1,0 +1,34 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // config.js reads the environment once at import time, so these have to be set before any
+    // module under test is loaded - vitest applies them to the worker process for us.
+    // They have to agree with docker-compose.itest.yml: the pod FQDNs the mongods answer to are built
+    // from the service name, namespace and cluster domain here.
+    env: {
+      KUBE_CLUSTER_DOMAIN: "cluster.local",
+      KUBE_MONGO_SERVICE_NAME: "db",
+      KUBE_NAMESPACE: "test-ns",
+      // A real election has to be allowed to finish inside this, or the tests measure the fence rather
+      // than the sidecar - but every scenario that needs a forced reconfig waits it out, so keep it
+      // just past mongod's 10s election timeout rather than at the 30s default.
+      MONGODB_FORCE_RECONFIG_GRACE_SECONDS: "15",
+      MONGODB_PORT: "27017",
+      // Both grace periods have to be short, and both matter: whether a killed member is reaped
+      // under unhealthySeconds or under the startup grace depends on whether mongod still reports a
+      // lastHeartbeatRecv for it, which it does inconsistently. Leaving the startup grace at its
+      // 300s default makes the reap test a coin toss.
+      MONGODB_STARTUP_GRACE_SECONDS: "8",
+      MONGODB_UNHEALTHY_SECONDS: "5",
+    },
+    // The scenarios share one replica set and walk it through a lifecycle, so they must not race
+    fileParallelism: false,
+    hookTimeout: 180_000,
+    include: ["tests/**/*.integration.test.ts"],
+    // Where the junit reporter writes when enabled - see docker-compose.itest.yml
+    outputFile: { junit: "reports/integration-junit.xml" },
+    // Real elections, initial syncs and heartbeat timeouts, none of which are fast
+    testTimeout: 180_000,
+  },
+});


### PR DESCRIPTION
Sidecar gains member-host normalisation (rename replset members to stable service DNS), forced reinit on invalid replset config, unhealthy-member tracking with startup grace, lazy k8s client, and a new vitest unit + integration test suite.

